### PR TITLE
feat: multi-backend read support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ For MCP usage across multiple repos, each tool accepts an optional
 }
 ```
 
+Remote backends (CloudWatch/K8s) require optional SDK installs; install only if you use them.
+
 ### Environment overrides
 - `HUNCH_CONFIG_PATH` — explicit config path
 - `HUNCH_DIR` — store dir override

--- a/packages/hunch-js/package.json
+++ b/packages/hunch-js/package.json
@@ -34,6 +34,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.26.0"
   },
+  "optionalDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "3.985.0",
+    "@aws-sdk/credential-providers": "3.985.0",
+    "@kubernetes/client-node": "1.4.0"
+  },
   "devDependencies": {
     "@types/node": "25.2.2"
   }

--- a/packages/hunch-js/src/config.ts
+++ b/packages/hunch-js/src/config.ts
@@ -12,6 +12,9 @@ const DEFAULT_CONFIG: HunchConfig = {
     capture_stdout: true,
     capture_stderr: true,
   },
+  read: {
+    backend: "local",
+  },
   redaction: {
     enabled: true,
     keys: ["authorization", "api_key", "token", "secret", "password"],
@@ -77,6 +80,11 @@ const mergeConfig = (base: HunchConfig, override: Partial<HunchConfig>): HunchCo
     ...base,
     ...override,
     sdk: mergeSdkConfig(base.sdk, override.sdk),
+    read: {
+      ...(base.read ?? { backend: "local" }),
+      ...(override.read ?? {}),
+      backends: override.read?.backends ?? base.read?.backends,
+    },
     redaction: {
       ...base.redaction,
       ...(override.redaction ?? {}),

--- a/packages/hunch-js/src/schema.ts
+++ b/packages/hunch-js/src/schema.ts
@@ -6,6 +6,8 @@ export type HunchSource = {
   kind: HunchSourceKind;
   file?: string;
   line?: number;
+  backend?: string;
+  backend_id?: string;
 };
 
 export type HunchSdkConfig = {
@@ -36,6 +38,7 @@ export type HunchConfig = {
   store_dir: string;
   default_service: string;
   sdk: HunchSdkConfig;
+  read?: HunchReadConfig;
   redaction: {
     enabled: boolean;
     keys: string[];
@@ -45,6 +48,43 @@ export type HunchConfig = {
     max_results: number;
     default_lookback_ms: number;
   };
+};
+
+export type HunchReadBackendType = "local" | "cloudwatch" | "k8s";
+
+export type LocalReadBackendConfig = {
+  type: "local";
+  id?: string;
+  dir?: string;
+};
+
+export type CloudWatchReadBackendConfig = {
+  type: "cloudwatch";
+  id?: string;
+  logGroup: string;
+  region: string;
+  profile?: string;
+  service?: string;
+};
+
+export type K8sReadBackendConfig = {
+  type: "k8s";
+  id?: string;
+  namespace: string;
+  selector: string;
+  context?: string;
+  container?: string;
+  service?: string;
+};
+
+export type HunchReadBackendConfig =
+  | LocalReadBackendConfig
+  | CloudWatchReadBackendConfig
+  | K8sReadBackendConfig;
+
+export type HunchReadConfig = {
+  backend: "local" | "multi";
+  backends?: HunchReadBackendConfig[];
 };
 
 export type HunchSearchParams = {
@@ -57,6 +97,7 @@ export type HunchSearchParams = {
   since?: string;
   until?: string;
   limit?: number;
+  backends?: string[];
   config_path?: string;
 };
 
@@ -67,6 +108,7 @@ export type HunchStatsParams = {
   until?: string;
   group_by: "type" | "level" | "stage";
   limit?: number;
+  backends?: string[];
   config_path?: string;
 };
 
@@ -74,6 +116,7 @@ export type HunchSessionsParams = {
   service?: string;
   since?: string;
   limit?: number;
+  backends?: string[];
   config_path?: string;
 };
 
@@ -82,5 +125,6 @@ export type HunchTailParams = {
   session_id?: string;
   run_id?: string;
   limit?: number;
+  backends?: string[];
   config_path?: string;
 };

--- a/packages/hunch-js/src/store/backends/cloudwatch.ts
+++ b/packages/hunch-js/src/store/backends/cloudwatch.ts
@@ -1,0 +1,373 @@
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import {
+  CloudWatchReadBackendConfig,
+  HunchEvent,
+  HunchSearchParams,
+  HunchSessionsParams,
+  HunchStatsParams,
+} from "../../schema.js";
+import { eventMatches, normalizeLevel } from "../filters.js";
+import { normalizeTimestamp, parseTimeInput } from "../time.js";
+import { ReadBackend, SearchResult, SessionsResult, StatsResult } from "./types.js";
+
+type AwsClient = {
+  send: (command: unknown) => Promise<{
+    events?: Array<{
+      eventId?: string;
+      timestamp?: number;
+      message?: string;
+      logStreamName?: string;
+    }>;
+    nextToken?: string;
+  }>;
+};
+
+const inferLevel = (message?: string): "fatal" | "error" | "warn" | "info" | "debug" | "trace" => {
+  const text = message?.toLowerCase() ?? "";
+  if (text.includes("fatal")) {
+    return "fatal";
+  }
+  if (text.includes("error")) {
+    return "error";
+  }
+  if (text.includes("warn")) {
+    return "warn";
+  }
+  if (text.includes("debug")) {
+    return "debug";
+  }
+  if (text.includes("trace")) {
+    return "trace";
+  }
+  return "info";
+};
+
+const deriveService = (logGroup: string): string => {
+  const trimmed = logGroup.trim();
+  const parts = trimmed.split("/");
+  const last = parts[parts.length - 1];
+  return last && last.length > 0 ? last : trimmed;
+};
+
+const isHunchLikeObject = (value: Record<string, unknown>): boolean => {
+  const keys = [
+    "id",
+    "ts",
+    "level",
+    "type",
+    "service",
+    "run_id",
+    "session_id",
+    "message",
+    "data",
+    "tags",
+    "trace_id",
+    "span_id",
+    "source",
+  ];
+  return keys.some((key) => key in value);
+};
+
+const extractTags = (value: unknown): Record<string, string> | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof entry === "string") {
+      record[key] = entry;
+    }
+  }
+  return Object.keys(record).length > 0 ? record : undefined;
+};
+
+const extractData = (
+  value: Record<string, unknown>,
+  fallbackMessage: string | undefined,
+): Record<string, unknown> | undefined => {
+  if (value.data && typeof value.data === "object" && value.data !== null) {
+    return value.data as Record<string, unknown>;
+  }
+  const knownKeys = new Set([
+    "id",
+    "ts",
+    "level",
+    "type",
+    "service",
+    "run_id",
+    "session_id",
+    "message",
+    "data",
+    "tags",
+    "trace_id",
+    "span_id",
+    "source",
+  ]);
+  const extra: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!knownKeys.has(key)) {
+      extra[key] = entry;
+    }
+  }
+  if (Object.keys(extra).length === 0) {
+    return fallbackMessage ? { raw_message: fallbackMessage } : undefined;
+  }
+  return extra;
+};
+
+const normalizeSource = (
+  source: unknown,
+  backendId?: string,
+): { kind: "mcp"; backend: "cloudwatch"; backend_id?: string } & Record<string, unknown> => {
+  const base =
+    source && typeof source === "object" ? (source as Record<string, unknown>) : {};
+  return {
+    ...base,
+    kind: "mcp",
+    backend: "cloudwatch",
+    backend_id: backendId ?? (base.backend_id as string | undefined),
+  };
+};
+
+const toEvent = (
+  config: CloudWatchReadBackendConfig,
+  logEvent: { eventId?: string; timestamp?: number; message?: string; logStreamName?: string },
+): HunchEvent => {
+  const rawMessage = logEvent.message ?? "";
+  const trimmed = rawMessage.trim();
+  const parsedTs = logEvent.timestamp ? new Date(logEvent.timestamp).toISOString() : new Date().toISOString();
+  const id = logEvent.eventId ?? randomUUID();
+  const service = config.service ?? deriveService(config.logGroup);
+  const runId = logEvent.logStreamName ?? logEvent.eventId ?? id;
+  const fallback = {
+    id,
+    ts: parsedTs,
+    level: inferLevel(rawMessage),
+    type: "log",
+    service,
+    run_id: runId,
+    message: rawMessage,
+    data: { logStreamName: logEvent.logStreamName, raw_message: rawMessage },
+    source: normalizeSource(undefined, config.id),
+  } satisfies HunchEvent;
+
+  if (!trimmed.startsWith("{")) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object") {
+      return fallback;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (!isHunchLikeObject(record)) {
+      return fallback;
+    }
+
+    const level = normalizeLevel(record.level as string | undefined) ?? inferLevel(rawMessage);
+    const message =
+      typeof record.message === "string" ? record.message : rawMessage || undefined;
+    const source = normalizeSource(record.source, config.id);
+
+    return {
+      id: typeof record.id === "string" ? record.id : id,
+      ts: typeof record.ts === "string" ? record.ts : parsedTs,
+      level,
+      type: typeof record.type === "string" ? record.type : "log",
+      service: typeof record.service === "string" ? record.service : service,
+      run_id: typeof record.run_id === "string" ? record.run_id : runId,
+      session_id: typeof record.session_id === "string" ? record.session_id : undefined,
+      message,
+      data: extractData(record, rawMessage),
+      tags: extractTags(record.tags),
+      trace_id: typeof record.trace_id === "string" ? record.trace_id : undefined,
+      span_id: typeof record.span_id === "string" ? record.span_id : undefined,
+      source,
+    };
+  } catch {
+    return fallback;
+  }
+};
+
+const requireModule = createRequire(import.meta.url);
+
+const loadSdk = (): {
+  CloudWatchLogsClient: new (config: { region: string; credentials?: unknown }) => AwsClient;
+  FilterLogEventsCommand: new (input: {
+    logGroupName: string;
+    startTime?: number;
+    endTime?: number;
+    nextToken?: string;
+    limit?: number;
+  }) => unknown;
+} => {
+  try {
+    return requireModule("@aws-sdk/client-cloudwatch-logs");
+  } catch {
+    throw new Error(
+      "CloudWatch backend requires @aws-sdk/client-cloudwatch-logs. Install it to enable this backend.",
+    );
+  }
+};
+
+const loadCredentialProviders = (): { fromIni: (input: { profile: string }) => unknown } => {
+  try {
+    return requireModule("@aws-sdk/credential-providers");
+  } catch {
+    throw new Error(
+      "CloudWatch backend requires @aws-sdk/credential-providers when using profile override.",
+    );
+  }
+};
+
+export const createCloudWatchBackend = (
+  config: CloudWatchReadBackendConfig,
+): ReadBackend => {
+  let client: AwsClient | null = null;
+  let FilterLogEventsCommand: ReturnType<typeof loadSdk>["FilterLogEventsCommand"] | null = null;
+  const getClient = (): { client: AwsClient; FilterLogEventsCommand: ReturnType<typeof loadSdk>["FilterLogEventsCommand"] } => {
+    if (client && FilterLogEventsCommand) {
+      return { client, FilterLogEventsCommand };
+    }
+    const sdk = loadSdk();
+    FilterLogEventsCommand = sdk.FilterLogEventsCommand;
+    const credentials = config.profile
+      ? loadCredentialProviders().fromIni({ profile: config.profile })
+      : undefined;
+    const sdkClient = new sdk.CloudWatchLogsClient({
+      region: config.region,
+      credentials,
+    });
+    client = {
+      send: (command) => sdkClient.send(command as unknown),
+    };
+    return { client, FilterLogEventsCommand };
+  };
+
+  const fetchEvents = async (
+    params: HunchSearchParams,
+  ): Promise<SearchResult> => {
+    const { client, FilterLogEventsCommand } = getClient();
+    const limit = params.limit ?? 200;
+    const sinceMs = params.since ? parseTimeInput(params.since) : undefined;
+    const untilMs = params.until ? parseTimeInput(params.until) : undefined;
+    const events: HunchEvent[] = [];
+    let truncated = false;
+    let nextToken: string | undefined = undefined;
+
+    do {
+      const remaining = Math.max(limit - events.length, 1);
+      const response = await client.send(
+        new FilterLogEventsCommand({
+          logGroupName: config.logGroup,
+          startTime: sinceMs,
+          endTime: untilMs,
+          nextToken,
+          limit: Math.min(remaining, 10000),
+        }),
+      );
+      const batch = response.events ?? [];
+      for (const logEvent of batch) {
+        const event = toEvent(config, logEvent);
+        if (!eventMatches(event, params, sinceMs, untilMs)) {
+          continue;
+        }
+        events.push(event);
+        if (events.length >= limit) {
+          truncated = true;
+          break;
+        }
+      }
+      const receivedToken = response.nextToken;
+      if (receivedToken && receivedToken === nextToken) {
+        break;
+      }
+      nextToken = receivedToken;
+    } while (nextToken && !truncated);
+
+    if (nextToken) {
+      truncated = true;
+    }
+
+    return { events, truncated };
+  };
+
+  const stats = async (params: HunchStatsParams): Promise<StatsResult> => {
+    const searchParams: HunchSearchParams = {
+      service: params.service,
+      session_id: params.session_id,
+      since: params.since,
+      until: params.until,
+      limit: params.limit ?? 1000,
+    };
+    const result = await fetchEvents(searchParams);
+    const buckets = new Map<string, number>();
+    for (const event of result.events) {
+      let key = "unknown";
+      if (params.group_by === "type") {
+        key = event.type;
+      } else if (params.group_by === "level") {
+        key = event.level;
+      } else if (params.group_by === "stage") {
+        const stage = (event.data as Record<string, unknown> | undefined)?.stage;
+        key = typeof stage === "string" ? stage : "unknown";
+      }
+      buckets.set(key, (buckets.get(key) ?? 0) + 1);
+    }
+    const limit = params.limit ?? 200;
+    const sorted = [...buckets.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([key, count]) => ({ key, count }));
+    return { buckets: sorted };
+  };
+
+  const sessions = async (params: HunchSessionsParams): Promise<SessionsResult> => {
+    const searchParams: HunchSearchParams = {
+      service: params.service,
+      since: params.since,
+      limit: params.limit ?? 1000,
+    };
+    const result = await fetchEvents(searchParams);
+    const sessions = new Map<
+      string,
+      { session_id: string; last_ts: string; event_count: number; error_count: number }
+    >();
+    for (const event of result.events) {
+      if (!event.session_id) {
+        continue;
+      }
+      const existing = sessions.get(event.session_id) ?? {
+        session_id: event.session_id,
+        last_ts: event.ts,
+        event_count: 0,
+        error_count: 0,
+      };
+      existing.event_count += 1;
+      if (event.level === "error" || event.level === "fatal") {
+        existing.error_count += 1;
+      }
+      const existingTs = normalizeTimestamp(existing.last_ts) ?? 0;
+      const eventTs = normalizeTimestamp(event.ts) ?? 0;
+      if (eventTs > existingTs) {
+        existing.last_ts = event.ts;
+      }
+      sessions.set(event.session_id, existing);
+    }
+
+    const limit = params.limit ?? 200;
+    const sorted = [...sessions.values()]
+      .sort((a, b) => (normalizeTimestamp(b.last_ts) ?? 0) - (normalizeTimestamp(a.last_ts) ?? 0))
+      .slice(0, limit);
+
+    return { sessions: sorted };
+  };
+
+  return {
+    search: fetchEvents,
+    stats,
+    sessions,
+  };
+};

--- a/packages/hunch-js/src/store/backends/k8s.ts
+++ b/packages/hunch-js/src/store/backends/k8s.ts
@@ -1,0 +1,400 @@
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import {
+  HunchEvent,
+  HunchSearchParams,
+  HunchSessionsParams,
+  HunchStatsParams,
+  K8sReadBackendConfig,
+} from "../../schema.js";
+import { eventMatches, normalizeLevel } from "../filters.js";
+import { normalizeTimestamp, parseTimeInput } from "../time.js";
+import { ReadBackend, SearchResult, SessionsResult, StatsResult } from "./types.js";
+
+type K8sClient = {
+  listNamespacedPod: (
+    namespace: string,
+    pretty?: string,
+    allowWatchBookmarks?: boolean,
+    _continue?: string,
+    fieldSelector?: string,
+    labelSelector?: string,
+  ) => Promise<{ body: { items: Array<{ metadata?: { name?: string } }> } }>;
+  readNamespacedPodLog: (
+    name: string,
+    namespace: string,
+    container?: string,
+    follow?: boolean,
+    pretty?: string,
+    previous?: boolean,
+    sinceSeconds?: number,
+    sinceTime?: string,
+    timestamps?: boolean,
+    tailLines?: number,
+    limitBytes?: number,
+  ) => Promise<{ body: string }>;
+};
+
+const inferLevel = (message?: string): "fatal" | "error" | "warn" | "info" | "debug" | "trace" => {
+  const text = message?.toLowerCase() ?? "";
+  if (text.includes("fatal")) {
+    return "fatal";
+  }
+  if (text.includes("error")) {
+    return "error";
+  }
+  if (text.includes("warn")) {
+    return "warn";
+  }
+  if (text.includes("debug")) {
+    return "debug";
+  }
+  if (text.includes("trace")) {
+    return "trace";
+  }
+  return "info";
+};
+
+const deriveService = (selector: string): string | undefined => {
+  const first = selector.split(",")[0]?.trim();
+  if (!first) {
+    return undefined;
+  }
+  const parts = first.split("=");
+  if (parts.length === 2 && parts[1]) {
+    return parts[1].trim();
+  }
+  return undefined;
+};
+
+const isHunchLikeObject = (value: Record<string, unknown>): boolean => {
+  const keys = [
+    "id",
+    "ts",
+    "level",
+    "type",
+    "service",
+    "run_id",
+    "session_id",
+    "message",
+    "data",
+    "tags",
+    "trace_id",
+    "span_id",
+    "source",
+  ];
+  return keys.some((key) => key in value);
+};
+
+const extractTags = (value: unknown): Record<string, string> | undefined => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof entry === "string") {
+      record[key] = entry;
+    }
+  }
+  return Object.keys(record).length > 0 ? record : undefined;
+};
+
+const extractData = (
+  value: Record<string, unknown>,
+  fallback: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  if (value.data && typeof value.data === "object" && value.data !== null) {
+    return value.data as Record<string, unknown>;
+  }
+  const knownKeys = new Set([
+    "id",
+    "ts",
+    "level",
+    "type",
+    "service",
+    "run_id",
+    "session_id",
+    "message",
+    "data",
+    "tags",
+    "trace_id",
+    "span_id",
+    "source",
+  ]);
+  const extra: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (!knownKeys.has(key)) {
+      extra[key] = entry;
+    }
+  }
+  if (Object.keys(extra).length === 0) {
+    return fallback;
+  }
+  return extra;
+};
+
+const normalizeSource = (
+  source: unknown,
+  backendId?: string,
+): { kind: "mcp"; backend: "k8s"; backend_id?: string } & Record<string, unknown> => {
+  const base =
+    source && typeof source === "object" ? (source as Record<string, unknown>) : {};
+  return {
+    ...base,
+    kind: "mcp",
+    backend: "k8s",
+    backend_id: backendId ?? (base.backend_id as string | undefined),
+  };
+};
+
+const toEvent = (
+  config: K8sReadBackendConfig,
+  message: string,
+  ts: string,
+  pod: string,
+  container?: string,
+): HunchEvent => {
+  const trimmed = message.trim();
+  const service = config.service ?? deriveService(config.selector) ?? "k8s";
+  const runId = pod;
+  const fallbackData: Record<string, unknown> = { pod, container, raw_message: message };
+  const fallback: HunchEvent = {
+    id: randomUUID(),
+    ts,
+    level: inferLevel(message),
+    type: "log",
+    service,
+    run_id: runId,
+    message,
+    data: fallbackData,
+    source: normalizeSource(undefined, config.id),
+  };
+
+  if (!trimmed.startsWith("{")) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object") {
+      return fallback;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (!isHunchLikeObject(record)) {
+      return fallback;
+    }
+
+    const level = normalizeLevel(record.level as string | undefined) ?? inferLevel(message);
+    const eventMessage = typeof record.message === "string" ? record.message : message;
+    const source = normalizeSource(record.source, config.id);
+    return {
+      id: typeof record.id === "string" ? record.id : fallback.id,
+      ts: typeof record.ts === "string" ? record.ts : ts,
+      level,
+      type: typeof record.type === "string" ? record.type : "log",
+      service: typeof record.service === "string" ? record.service : service,
+      run_id: typeof record.run_id === "string" ? record.run_id : runId,
+      session_id: typeof record.session_id === "string" ? record.session_id : undefined,
+      message: eventMessage,
+      data: extractData(record, fallbackData),
+      tags: extractTags(record.tags),
+      trace_id: typeof record.trace_id === "string" ? record.trace_id : undefined,
+      span_id: typeof record.span_id === "string" ? record.span_id : undefined,
+      source,
+    };
+  } catch {
+    return fallback;
+  }
+};
+
+const requireModule = createRequire(import.meta.url);
+
+const loadClient = (context?: string): K8sClient => {
+  let module: {
+    KubeConfig: new () => {
+      loadFromDefault: () => void;
+      setCurrentContext: (ctx: string) => void;
+      makeApiClient: (api: unknown) => unknown;
+    };
+    CoreV1Api: new () => unknown;
+  };
+  try {
+    module = requireModule("@kubernetes/client-node");
+  } catch {
+    throw new Error(
+      "Kubernetes backend requires @kubernetes/client-node. Install it to enable this backend.",
+    );
+  }
+
+  const { KubeConfig, CoreV1Api } = module;
+  const kc = new KubeConfig();
+  kc.loadFromDefault();
+  if (context) {
+    kc.setCurrentContext(context);
+  }
+  const client = kc.makeApiClient(CoreV1Api) as unknown as K8sClient;
+  return client;
+};
+
+const parseLogLine = (line: string): { ts: string; message: string } => {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return { ts: new Date().toISOString(), message: "" };
+  }
+  const space = trimmed.indexOf(" ");
+  if (space > 0) {
+    const possibleTs = trimmed.slice(0, space);
+    const parsed = Date.parse(possibleTs);
+    if (!Number.isNaN(parsed)) {
+      return { ts: new Date(parsed).toISOString(), message: trimmed.slice(space + 1) };
+    }
+  }
+  return { ts: new Date().toISOString(), message: trimmed };
+};
+
+export const createK8sBackend = (config: K8sReadBackendConfig): ReadBackend => {
+  let client: K8sClient | null = null;
+  const getClient = (): K8sClient => {
+    if (!client) {
+      client = loadClient(config.context);
+    }
+    return client;
+  };
+
+  const fetchEvents = async (params: HunchSearchParams): Promise<SearchResult> => {
+    const client = getClient();
+    const sinceMs = params.since ? parseTimeInput(params.since) : undefined;
+    const untilMs = params.until ? parseTimeInput(params.until) : undefined;
+    const sinceSeconds =
+      sinceMs && sinceMs < Date.now()
+        ? Math.max(1, Math.floor((Date.now() - sinceMs) / 1000))
+        : undefined;
+    const limit = params.limit ?? 200;
+    const events: HunchEvent[] = [];
+    let truncated = false;
+
+    const pods = await client.listNamespacedPod(
+      config.namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      config.selector,
+    );
+
+    for (const pod of pods.body.items) {
+      const podName = pod.metadata?.name;
+      if (!podName) {
+        continue;
+      }
+      const response = await client.readNamespacedPodLog(
+        podName,
+        config.namespace,
+        config.container,
+        false,
+        undefined,
+        undefined,
+        sinceSeconds,
+        undefined,
+        true,
+      );
+      const lines = response.body.split(/\r?\n/);
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        const { ts, message } = parseLogLine(line);
+        const event = toEvent(config, message, ts, podName, config.container);
+        if (!eventMatches(event, params, sinceMs, untilMs)) {
+          continue;
+        }
+        events.push(event);
+        if (events.length >= limit) {
+          truncated = true;
+          break;
+        }
+      }
+      if (truncated) {
+        break;
+      }
+    }
+
+    return { events, truncated };
+  };
+
+  const stats = async (params: HunchStatsParams): Promise<StatsResult> => {
+    const searchParams: HunchSearchParams = {
+      service: params.service,
+      session_id: params.session_id,
+      since: params.since,
+      until: params.until,
+      limit: params.limit ?? 1000,
+    };
+    const result = await fetchEvents(searchParams);
+    const buckets = new Map<string, number>();
+    for (const event of result.events) {
+      let key = "unknown";
+      if (params.group_by === "type") {
+        key = event.type;
+      } else if (params.group_by === "level") {
+        key = event.level;
+      } else if (params.group_by === "stage") {
+        const stage = (event.data as Record<string, unknown> | undefined)?.stage;
+        key = typeof stage === "string" ? stage : "unknown";
+      }
+      buckets.set(key, (buckets.get(key) ?? 0) + 1);
+    }
+    const limit = params.limit ?? 200;
+    const sorted = [...buckets.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([key, count]) => ({ key, count }));
+    return { buckets: sorted };
+  };
+
+  const sessions = async (params: HunchSessionsParams): Promise<SessionsResult> => {
+    const searchParams: HunchSearchParams = {
+      service: params.service,
+      since: params.since,
+      limit: params.limit ?? 1000,
+    };
+    const result = await fetchEvents(searchParams);
+    const sessions = new Map<
+      string,
+      { session_id: string; last_ts: string; event_count: number; error_count: number }
+    >();
+    for (const event of result.events) {
+      if (!event.session_id) {
+        continue;
+      }
+      const existing = sessions.get(event.session_id) ?? {
+        session_id: event.session_id,
+        last_ts: event.ts,
+        event_count: 0,
+        error_count: 0,
+      };
+      existing.event_count += 1;
+      if (event.level === "error" || event.level === "fatal") {
+        existing.error_count += 1;
+      }
+      const existingTs = normalizeTimestamp(existing.last_ts) ?? 0;
+      const eventTs = normalizeTimestamp(event.ts) ?? 0;
+      if (eventTs > existingTs) {
+        existing.last_ts = event.ts;
+      }
+      sessions.set(event.session_id, existing);
+    }
+
+    const limit = params.limit ?? 200;
+    const sorted = [...sessions.values()]
+      .sort((a, b) => (normalizeTimestamp(b.last_ts) ?? 0) - (normalizeTimestamp(a.last_ts) ?? 0))
+      .slice(0, limit);
+    return { sessions: sorted };
+  };
+
+  return {
+    search: fetchEvents,
+    stats,
+    sessions,
+  };
+};

--- a/packages/hunch-js/src/store/backends/local.ts
+++ b/packages/hunch-js/src/store/backends/local.ts
@@ -1,0 +1,41 @@
+import { HunchConfig, HunchEvent, HunchSearchParams, HunchStatsParams, HunchSessionsParams } from "../../schema.js";
+import { listSessions, searchEvents, statsEvents } from "../file-store.js";
+import { ReadBackend, SearchResult, SessionsResult, StatsResult } from "./types.js";
+
+type LocalBackendOptions = {
+  storeDir: string;
+  config: HunchConfig;
+  backendId?: string;
+};
+
+const tagLocalSource = (event: HunchEvent, backendId?: string): HunchEvent => {
+  const source = event.source ?? { kind: "mcp" as const };
+  return {
+    ...event,
+    source: {
+      ...source,
+      backend: "local",
+      backend_id: backendId ?? source.backend_id,
+    },
+  };
+};
+
+export const createLocalBackend = (options: LocalBackendOptions): ReadBackend => {
+  const { storeDir, config, backendId } = options;
+
+  return {
+    search: async (params: HunchSearchParams): Promise<SearchResult> => {
+      const result = await searchEvents(storeDir, config, params);
+      return {
+        ...result,
+        events: result.events.map((event) => tagLocalSource(event, backendId)),
+      };
+    },
+    stats: async (params: HunchStatsParams): Promise<StatsResult> => {
+      return statsEvents(storeDir, config, params);
+    },
+    sessions: async (params: HunchSessionsParams): Promise<SessionsResult> => {
+      return listSessions(storeDir, config, params);
+    },
+  };
+};

--- a/packages/hunch-js/src/store/backends/types.ts
+++ b/packages/hunch-js/src/store/backends/types.ts
@@ -1,0 +1,18 @@
+import {
+  HunchEvent,
+  HunchSearchParams,
+  HunchStatsParams,
+  HunchSessionsParams,
+} from "../../schema.js";
+
+export type SearchResult = { events: HunchEvent[]; truncated: boolean };
+export type StatsResult = { buckets: Array<{ key: string; count: number }> };
+export type SessionsResult = {
+  sessions: Array<{ session_id: string; last_ts: string; event_count: number; error_count: number }>;
+};
+
+export type ReadBackend = {
+  search: (params: HunchSearchParams) => Promise<SearchResult>;
+  stats: (params: HunchStatsParams) => Promise<StatsResult>;
+  sessions: (params: HunchSessionsParams) => Promise<SessionsResult>;
+};

--- a/packages/hunch-js/src/store/file-store.ts
+++ b/packages/hunch-js/src/store/file-store.ts
@@ -4,12 +4,12 @@ import readline from "node:readline";
 import {
   HunchConfig,
   HunchEvent,
-  HunchLevel,
   HunchSearchParams,
   HunchSessionsParams,
   HunchStatsParams,
 } from "../schema.js";
 import { parseTimeInput, normalizeTimestamp, formatDateSegment } from "./time.js";
+import { eventMatches } from "./filters.js";
 
 const ensureDir = async (dir: string): Promise<void> => {
   await fs.promises.mkdir(dir, { recursive: true });
@@ -19,64 +19,6 @@ const getEventTimestamp = (event: HunchEvent): number | undefined => {
   return normalizeTimestamp(event.ts);
 };
 
-const matchesContains = (event: HunchEvent, needle: string): boolean => {
-  const lower = needle.toLowerCase();
-  const message = event.message?.toLowerCase() ?? "";
-  if (message.includes(lower)) {
-    return true;
-  }
-  if (event.type.toLowerCase().includes(lower)) {
-    return true;
-  }
-  if (event.session_id?.toLowerCase().includes(lower)) {
-    return true;
-  }
-  if (event.data) {
-    try {
-      const serialized = JSON.stringify(event.data).toLowerCase();
-      if (serialized.includes(lower)) {
-        return true;
-      }
-    } catch {
-      return false;
-    }
-  }
-  return false;
-};
-
-const eventMatches = (
-  event: HunchEvent,
-  params: HunchSearchParams,
-  sinceMs?: number,
-  untilMs?: number,
-): boolean => {
-  if (params.service && event.service !== params.service) {
-    return false;
-  }
-  if (params.session_id && event.session_id !== params.session_id) {
-    return false;
-  }
-  if (params.run_id && event.run_id !== params.run_id) {
-    return false;
-  }
-  if (params.types && params.types.length > 0 && !params.types.includes(event.type)) {
-    return false;
-  }
-  if (params.levels && params.levels.length > 0 && !params.levels.includes(event.level)) {
-    return false;
-  }
-  if (params.contains && !matchesContains(event, params.contains)) {
-    return false;
-  }
-  const ts = getEventTimestamp(event);
-  if (sinceMs !== undefined && ts !== undefined && ts < sinceMs) {
-    return false;
-  }
-  if (untilMs !== undefined && ts !== undefined && ts > untilMs) {
-    return false;
-  }
-  return true;
-};
 
 const collectFiles = async (root: string, service?: string): Promise<string[]> => {
   const storeRoot = service ? path.join(root, service) : root;
@@ -273,22 +215,4 @@ export const listSessions = async (
     .slice(0, limit);
 
   return { sessions: sorted };
-};
-
-export const normalizeLevel = (level?: string): HunchLevel | undefined => {
-  if (!level) {
-    return undefined;
-  }
-  const value = level.toLowerCase();
-  if (
-    value === "trace" ||
-    value === "debug" ||
-    value === "info" ||
-    value === "warn" ||
-    value === "error" ||
-    value === "fatal"
-  ) {
-    return value;
-  }
-  return undefined;
 };

--- a/packages/hunch-js/src/store/filters.ts
+++ b/packages/hunch-js/src/store/filters.ts
@@ -1,0 +1,83 @@
+import { HunchEvent, HunchLevel, HunchSearchParams } from "../schema.js";
+import { normalizeTimestamp } from "./time.js";
+
+const matchesContains = (event: HunchEvent, needle: string): boolean => {
+  const lower = needle.toLowerCase();
+  const message = event.message?.toLowerCase() ?? "";
+  if (message.includes(lower)) {
+    return true;
+  }
+  if (event.type.toLowerCase().includes(lower)) {
+    return true;
+  }
+  if (event.session_id?.toLowerCase().includes(lower)) {
+    return true;
+  }
+  if (event.data) {
+    try {
+      const serialized = JSON.stringify(event.data).toLowerCase();
+      if (serialized.includes(lower)) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return false;
+};
+
+const getEventTimestamp = (event: HunchEvent): number | undefined => {
+  return normalizeTimestamp(event.ts);
+};
+
+export const eventMatches = (
+  event: HunchEvent,
+  params: HunchSearchParams,
+  sinceMs?: number,
+  untilMs?: number,
+): boolean => {
+  if (params.service && event.service !== params.service) {
+    return false;
+  }
+  if (params.session_id && event.session_id !== params.session_id) {
+    return false;
+  }
+  if (params.run_id && event.run_id !== params.run_id) {
+    return false;
+  }
+  if (params.types && params.types.length > 0 && !params.types.includes(event.type)) {
+    return false;
+  }
+  if (params.levels && params.levels.length > 0 && !params.levels.includes(event.level)) {
+    return false;
+  }
+  if (params.contains && !matchesContains(event, params.contains)) {
+    return false;
+  }
+  const ts = getEventTimestamp(event);
+  if (sinceMs !== undefined && ts !== undefined && ts < sinceMs) {
+    return false;
+  }
+  if (untilMs !== undefined && ts !== undefined && ts > untilMs) {
+    return false;
+  }
+  return true;
+};
+
+export const normalizeLevel = (level?: string): HunchLevel | undefined => {
+  if (!level) {
+    return undefined;
+  }
+  const value = level.toLowerCase();
+  if (
+    value === "trace" ||
+    value === "debug" ||
+    value === "info" ||
+    value === "warn" ||
+    value === "error" ||
+    value === "fatal"
+  ) {
+    return value;
+  }
+  return undefined;
+};

--- a/packages/hunch-js/src/store/read-store.ts
+++ b/packages/hunch-js/src/store/read-store.ts
@@ -1,0 +1,340 @@
+import path from "node:path";
+import { resolveStoreDir } from "../config.js";
+import {
+  HunchConfig,
+  HunchEvent,
+  HunchReadBackendConfig,
+  HunchSearchParams,
+  HunchSessionsParams,
+  HunchStatsParams,
+  HunchTailParams,
+} from "../schema.js";
+import { normalizeTimestamp } from "./time.js";
+import { createCloudWatchBackend } from "./backends/cloudwatch.js";
+import { createK8sBackend } from "./backends/k8s.js";
+import { createLocalBackend } from "./backends/local.js";
+import { ReadBackend } from "./backends/types.js";
+
+type BackendEntry = {
+  type: string;
+  id?: string;
+  backend: ReadBackend;
+};
+
+export type BackendError = { backend: string; backend_id?: string; message: string };
+
+type ResolvedBackends = {
+  backends: BackendEntry[];
+  errors: BackendError[];
+};
+
+const resolveLocalDir = (rootDir: string, storeDir: string, dir?: string): string => {
+  if (!dir) {
+    return storeDir;
+  }
+  if (path.isAbsolute(dir)) {
+    return dir;
+  }
+  return path.join(rootDir, dir);
+};
+
+const resolveBackends = (config: HunchConfig, rootDir: string): ResolvedBackends => {
+  const errors: BackendError[] = [];
+  const backends: BackendEntry[] = [];
+  const storeDir = resolveStoreDir(config, rootDir);
+  const readConfig = config.read ?? { backend: "local" };
+
+  const addBackend = (backendConfig: HunchReadBackendConfig): void => {
+    if (backendConfig.type === "local") {
+      const dir = resolveLocalDir(rootDir, storeDir, backendConfig.dir);
+      backends.push({
+        type: "local",
+        id: backendConfig.id,
+        backend: createLocalBackend({ storeDir: dir, config, backendId: backendConfig.id }),
+      });
+      return;
+    }
+
+    if (backendConfig.type === "cloudwatch") {
+      backends.push({
+        type: "cloudwatch",
+        id: backendConfig.id,
+        backend: createCloudWatchBackend(backendConfig),
+      });
+      return;
+    }
+
+    if (backendConfig.type === "k8s") {
+      backends.push({
+        type: "k8s",
+        id: backendConfig.id,
+        backend: createK8sBackend(backendConfig),
+      });
+      return;
+    }
+
+    const unknown = backendConfig as { type: string; id?: string };
+    errors.push({
+      backend: unknown.type,
+      backend_id: unknown.id,
+      message: `Unknown backend type: ${unknown.type}`,
+    });
+  };
+
+  if (readConfig.backend !== "multi") {
+    addBackend({ type: "local" });
+    return { backends, errors };
+  }
+
+  const configured = readConfig.backends ?? [];
+  if (configured.length === 0) {
+    addBackend({ type: "local" });
+    return { backends, errors };
+  }
+
+  for (const backendConfig of configured) {
+    addBackend(backendConfig);
+  }
+
+  return { backends, errors };
+};
+
+const filterBackends = (
+  entries: BackendEntry[],
+  filters?: string[],
+): BackendEntry[] => {
+  if (!filters || filters.length === 0) {
+    return entries;
+  }
+  const filterSet = new Set(filters);
+  return entries.filter((entry) => {
+    if (entry.id && filterSet.has(entry.id)) {
+      return true;
+    }
+    if (filterSet.has(entry.type)) {
+      return true;
+    }
+    return false;
+  });
+};
+
+const sortEventsDesc = (events: HunchEvent[]): HunchEvent[] => {
+  return [...events].sort((a, b) => {
+    const aTs = normalizeTimestamp(a.ts) ?? 0;
+    const bTs = normalizeTimestamp(b.ts) ?? 0;
+    return bTs - aTs;
+  });
+};
+
+export const readSearch = async (
+  config: HunchConfig,
+  rootDir: string,
+  params: HunchSearchParams,
+): Promise<{ events: HunchEvent[]; truncated: boolean; errors?: BackendError[] }> => {
+  const { backends, errors: resolveErrors } = resolveBackends(config, rootDir);
+  const selected = filterBackends(backends, params.backends);
+  const errors: BackendError[] = [...resolveErrors];
+
+  if (params.backends && params.backends.length > 0 && selected.length === 0) {
+    errors.push({
+      backend: "multi",
+      message: `No backends matched filter: ${params.backends.join(", ")}`,
+    });
+  }
+
+  const results = await Promise.all(
+    selected.map(async (entry) => {
+      try {
+        const result = await entry.backend.search(params);
+        return { entry, result };
+      } catch (error) {
+        errors.push({
+          backend: entry.type,
+          backend_id: entry.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    }),
+  );
+
+  const limit = params.limit ?? config.mcp.max_results;
+  const events: HunchEvent[] = [];
+  let truncated = false;
+
+  for (const item of results) {
+    if (!item) {
+      continue;
+    }
+    events.push(...item.result.events);
+    if (item.result.truncated) {
+      truncated = true;
+    }
+  }
+
+  const sorted = sortEventsDesc(events);
+  const mergedCount = sorted.length;
+  const sliced = sorted.slice(0, limit);
+  if (mergedCount > limit) {
+    truncated = true;
+  }
+
+  return {
+    events: sliced,
+    truncated,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+export const readStats = async (
+  config: HunchConfig,
+  rootDir: string,
+  params: HunchStatsParams,
+): Promise<{ buckets: Array<{ key: string; count: number }>; errors?: BackendError[] }> => {
+  const { backends, errors: resolveErrors } = resolveBackends(config, rootDir);
+  const selected = filterBackends(backends, params.backends);
+  const errors: BackendError[] = [...resolveErrors];
+
+  if (params.backends && params.backends.length > 0 && selected.length === 0) {
+    errors.push({
+      backend: "multi",
+      message: `No backends matched filter: ${params.backends.join(", ")}`,
+    });
+  }
+
+  const results = await Promise.all(
+    selected.map(async (entry) => {
+      try {
+        const result = await entry.backend.stats(params);
+        return { entry, result };
+      } catch (error) {
+        errors.push({
+          backend: entry.type,
+          backend_id: entry.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    }),
+  );
+
+  const buckets = new Map<string, number>();
+  for (const item of results) {
+    if (!item) {
+      continue;
+    }
+    for (const bucket of item.result.buckets) {
+      buckets.set(bucket.key, (buckets.get(bucket.key) ?? 0) + bucket.count);
+    }
+  }
+
+  const limit = params.limit ?? config.mcp.max_results;
+  const merged = [...buckets.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([key, count]) => ({ key, count }));
+
+  return {
+    buckets: merged,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+export const readSessions = async (
+  config: HunchConfig,
+  rootDir: string,
+  params: HunchSessionsParams,
+): Promise<{
+  sessions: Array<{ session_id: string; last_ts: string; event_count: number; error_count: number }>;
+  errors?: BackendError[];
+}> => {
+  const { backends, errors: resolveErrors } = resolveBackends(config, rootDir);
+  const selected = filterBackends(backends, params.backends);
+  const errors: BackendError[] = [...resolveErrors];
+
+  if (params.backends && params.backends.length > 0 && selected.length === 0) {
+    errors.push({
+      backend: "multi",
+      message: `No backends matched filter: ${params.backends.join(", ")}`,
+    });
+  }
+
+  const results = await Promise.all(
+    selected.map(async (entry) => {
+      try {
+        const result = await entry.backend.sessions(params);
+        return { entry, result };
+      } catch (error) {
+        errors.push({
+          backend: entry.type,
+          backend_id: entry.id,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      }
+    }),
+  );
+
+  const sessions = new Map<
+    string,
+    { session_id: string; last_ts: string; event_count: number; error_count: number }
+  >();
+  for (const item of results) {
+    if (!item) {
+      continue;
+    }
+    for (const session of item.result.sessions) {
+      const existing = sessions.get(session.session_id) ?? {
+        session_id: session.session_id,
+        last_ts: session.last_ts,
+        event_count: 0,
+        error_count: 0,
+      };
+      existing.event_count += session.event_count;
+      existing.error_count += session.error_count;
+      const existingTs = normalizeTimestamp(existing.last_ts) ?? 0;
+      const sessionTs = normalizeTimestamp(session.last_ts) ?? 0;
+      if (sessionTs > existingTs) {
+        existing.last_ts = session.last_ts;
+      }
+      sessions.set(session.session_id, existing);
+    }
+  }
+
+  const limit = params.limit ?? config.mcp.max_results;
+  const merged = [...sessions.values()]
+    .sort((a, b) => (normalizeTimestamp(b.last_ts) ?? 0) - (normalizeTimestamp(a.last_ts) ?? 0))
+    .slice(0, limit);
+
+  return {
+    sessions: merged,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+};
+
+export const readTail = async (
+  config: HunchConfig,
+  rootDir: string,
+  params: HunchTailParams & { since?: string },
+): Promise<{ events: HunchEvent[]; truncated: boolean; errors?: BackendError[] }> => {
+  const limit = params.limit ?? Math.min(config.mcp.max_results, 50);
+  const searchParams: HunchSearchParams = {
+    service: params.service,
+    session_id: params.session_id,
+    run_id: params.run_id,
+    since: params.since,
+    limit: config.mcp.max_results,
+    backends: params.backends,
+  };
+
+  const result = await readSearch(config, rootDir, searchParams);
+  const sorted = sortEventsDesc(result.events);
+  const sliced = sorted.slice(0, limit);
+  const truncated = result.truncated || sorted.length > limit;
+
+  return {
+    events: sliced,
+    truncated,
+    errors: result.errors,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,16 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
         version: 1.26.0(zod@4.3.6)
+    optionalDependencies:
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: 3.985.0
+        version: 3.985.0
+      '@aws-sdk/credential-providers':
+        specifier: 3.985.0
+        version: 3.985.0
+      '@kubernetes/client-node':
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       '@types/node':
         specifier: 25.2.2
@@ -20,11 +30,167 @@ importers:
 
 packages:
 
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-cloudwatch-logs@3.985.0':
+    resolution: {integrity: sha512-Spj9DvfbM3nUmBxpyuPhRww9TkJLM0mhNO0p53XAEaUcTZ3zUknhmDJ3rPZIZVEeQcLg4hFT6h7/46OiacJ17A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cognito-identity@3.980.0':
+    resolution: {integrity: sha512-nLgMW2drTzv+dTo3ORCcotQPcrUaTQ+xoaDTdSaUXdZO7zbbVyk7ysE5GDTnJdZWcUjHOSB8xfNQhOTTNVPhFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cognito-identity@3.985.0':
+    resolution: {integrity: sha512-PpHgiNGLsnQ2QHh0wx/uhGV3kxlASp2LOl5Z+LQCnu59i8rjAH1decT03QNWcho3Jz4zg9Kcto6VoAxu6OFb2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.985.0':
+    resolution: {integrity: sha512-81J8iE8MuXhdbMfIz4sWFj64Pe41bFi/uqqmqOC5SlGv+kwoyLsyKS/rH2tW2t5buih4vTUxskRjxlqikTD4oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.7':
+    resolution: {integrity: sha512-wNZZQQNlJ+hzD49cKdo+PY6rsTDElO8yDImnrI69p2PLBa7QomeUKAJWYp9xnaR38nlHqWhMHZuYLCQ3oSX+xg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.3':
+    resolution: {integrity: sha512-dW/DqTk90XW7hIngqntAVtJJyrkS51wcLhGz39lOMe0TlSmZl+5R/UGnAZqNbXmWuJHLzxe+MLgagxH41aTsAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.5':
+    resolution: {integrity: sha512-LxJ9PEO4gKPXzkufvIESUysykPIdrV7+Ocb9yAhbhJLE4TiAYqbCVUE+VuKP1leGR1bBfjWjYgSV5MxprlX3mQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.7':
+    resolution: {integrity: sha512-L2uOGtvp2x3bTcxFTpSM+GkwFIPd8pHfGWO1764icMbo7e5xJh0nfhx1UwkXLnwvocTNEf8A7jISZLYjUSNaTg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.5':
+    resolution: {integrity: sha512-SdDTYE6jkARzOeL7+kudMIM4DaFnP5dZVeatzw849k4bSXDdErDS188bgeNzc/RA2WGrlEpsqHUKP6G7sVXhZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.5':
+    resolution: {integrity: sha512-uYq1ILyTSI6ZDCMY5+vUsRM0SOCVI7kaW4wBrehVVkhAxC6y+e9rvGtnoZqCOWL1gKjTMouvsf4Ilhc5NCg1Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.6':
+    resolution: {integrity: sha512-DZ3CnAAtSVtVz+G+ogqecaErMLgzph4JH5nYbHoBMgBkwTUV+SUcjsjOJwdBJTHu3Dm6l5LBYekZoU2nDqQk2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.5':
+    resolution: {integrity: sha512-HDKF3mVbLnuqGg6dMnzBf1VUOywE12/N286msI9YaK9mEIzdsGCtLTvrDhe3Up0R9/hGFbB+9l21/TwF5L1C6g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.5':
+    resolution: {integrity: sha512-8urj3AoeNeQisjMmMBhFeiY2gxt6/7wQQbEGun0YV/OaOOiXrIudTIEYF8ZfD+NQI6X1FY5AkRsx6O/CaGiybA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.5':
+    resolution: {integrity: sha512-OK3cULuJl6c+RcDZfPpaK5o3deTOnKZbxm7pzhFNGA3fI2hF9yDih17fGRazJzGGWaDVlR9ejZrpDef4DJCEsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.985.0':
+    resolution: {integrity: sha512-mYjWyt0HiU3dYZif7yAJ+DYerSD/0bh7Umw9tUTFhhXrPePGTbJPyJx+vLmEh2dG2hCr7Qpn6DZdY8sB5yOxhQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.7':
+    resolution: {integrity: sha512-HUD+geASjXSCyL/DHPQc/Ua7JhldTcIglVAoCV8kiVm99IaFSlAbTvEnyhZwdE6bdFyTL+uIaWLaCFSRsglZBQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.985.0':
+    resolution: {integrity: sha512-TsWwKzb/2WHafAY0CE7uXgLj0FmnkBTgfioG9HO+7z/zCPcl1+YU+i7dW4o0y+aFxFgxTMG+ExBQpqT/k2ao8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.985.0':
+    resolution: {integrity: sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.980.0':
+    resolution: {integrity: sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.985.0':
+    resolution: {integrity: sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.5':
+    resolution: {integrity: sha512-GsUDF+rXyxDZkkJxUsDxnA67FG+kc5W1dnloCFLl6fWzceevsCYzJpASBzT+BPjwUgREE6FngfJYYYMQUY5fZQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.4':
+    resolution: {integrity: sha512-0zJ05ANfYqI6+rGqj8samZBFod0dPPousBjLEqg8WdxSgbMAkRgLyn81lP215Do0rFJ/17LIXwr7q0yK24mP6Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
+
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@1.4.0':
+    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
@@ -36,12 +202,220 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.22.1':
+    resolution: {integrity: sha512-x3ie6Crr58MWrm4viHqqy2Du2rHYZjwu8BekasrQx4ca+Y24dzVAwq3yErdqIbc2G3I0kLQA13PQ+/rde+u65g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.13':
+    resolution: {integrity: sha512-x6vn0PjYmGdNuKh/juUJJewZh7MoQ46jYaJ2mvekF4EesMuFfrl4LaW/k97Zjf8PTCPQmPgMvwewg7eNoH9n5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.30':
+    resolution: {integrity: sha512-CBGyFvN0f8hlnqKH/jckRDz78Snrp345+PVk8Ux7pnkUCW97Iinse59lY78hBt04h1GZ6hjBN94BRwZy1xC8Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.9':
+    resolution: {integrity: sha512-KX5Wml5mF+luxm1szW4QDz32e3NObgJ4Fyw+irhph4I/2geXwUy4jkIMUs5ZPGflRBeR6BUkC2wqIab4Llgm3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.2':
+    resolution: {integrity: sha512-SCkGmFak/xC1n7hKRsUr6wOnBTJ3L22Qd4e8H1fQIuKTAjntwgU8lrdMe7uHdiT2mJAOWA/60qaW9tiMu69n1A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.29':
+    resolution: {integrity: sha512-nIGy3DNRmOjaYaaKcQDzmWsro9uxlaqUOhZDHQed9MW/GmkBZPtnU70Pu1+GT9IBmUXwRdDuiyaeiy9Xtpn3+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.32':
+    resolution: {integrity: sha512-7dtFff6pu5fsjqrVve0YMhrnzJtccCWDacNKOkiZjJ++fmjGExmmSu341x+WU6Oc1IccL7lDuaUj7SfrHpWc5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.11':
+    resolution: {integrity: sha512-lKmZ0S/3Qj2OF5H1+VzvDLb6kRxGzZHq6f3rAsoSu5cTLGsn3v3VQBA8czkNNXlLjoFEtVu3OQT2jEeOtOE2CA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@24.10.12':
+    resolution: {integrity: sha512-68e+T28EbdmLSTkPgs3+UacC6rzmqrcWFPQs1C8mwJhI/r5Uxr0yEuQotczNRROd1gq30NGxee+fo0rSIxpyAw==}
+
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
+
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -54,9 +428,64 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  b4a@1.7.3:
+    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.5.3:
+    resolution: {integrity: sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.6.2:
+    resolution: {integrity: sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.7.0:
+    resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.3.2:
+    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.13.1:
+    resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -69,6 +498,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -103,6 +536,10 @@ packages:
       supports-color:
         optional: true
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -118,6 +555,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -130,12 +570,19 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -158,12 +605,23 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-parser@5.3.4:
+    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
+    hasBin: true
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -192,6 +650,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -199,6 +661,10 @@ packages:
   hono@4.11.8:
     resolution: {integrity: sha512-eVkB/CYCCei7K2WElZW9yYQFWssG0DhaDhVvr7wy5jJ22K+ck8fWW0EsLpB0sITUTvPnc97+rrbQqIr5iqiy9Q==}
     engines: {node: '>=16.9.0'}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -225,14 +691,32 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  jsonpath-plus@10.3.0:
+    resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -246,8 +730,16 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -260,6 +752,18 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  oauth4webapi@3.8.4:
+    resolution: {integrity: sha512-EKlVEgav8zH31IXxvhCqjEgQws6S9QmnmJyLXmeV5REf59g7VmqRVa5l/rhGWtUqGm2rLVTNwukn9hla5kJ2WQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -275,6 +779,9 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openid-client@6.8.2:
+    resolution: {integrity: sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -295,6 +802,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
@@ -310,6 +820,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -353,13 +866,50 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
+  streamx@2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+
+  tar-fs@3.1.1:
+    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -376,6 +926,12 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -383,6 +939,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -394,9 +962,589 @@ packages:
 
 snapshots:
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/client-cloudwatch-logs@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/client-cognito-identity@3.980.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.980.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/client-cognito-identity@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/client-sso@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/core@3.973.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.4
+      '@smithy/core': 3.22.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.3':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.980.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-env@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-http@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.11
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-ini@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-env': 3.972.5
+      '@aws-sdk/credential-provider-http': 3.972.7
+      '@aws-sdk/credential-provider-login': 3.972.5
+      '@aws-sdk/credential-provider-process': 3.972.5
+      '@aws-sdk/credential-provider-sso': 3.972.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.5
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-login@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-node@3.972.6':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.5
+      '@aws-sdk/credential-provider-http': 3.972.7
+      '@aws-sdk/credential-provider-ini': 3.972.5
+      '@aws-sdk/credential-provider-process': 3.972.5
+      '@aws-sdk/credential-provider-sso': 3.972.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.5
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-process@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/credential-provider-sso@3.972.5':
+    dependencies:
+      '@aws-sdk/client-sso': 3.985.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/token-providers': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-provider-web-identity@3.972.5':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/credential-providers@3.985.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.985.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.3
+      '@aws-sdk/credential-provider-env': 3.972.5
+      '@aws-sdk/credential-provider-http': 3.972.7
+      '@aws-sdk/credential-provider-ini': 3.972.5
+      '@aws-sdk/credential-provider-login': 3.972.5
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/credential-provider-process': 3.972.5
+      '@aws-sdk/credential-provider-sso': 3.972.5
+      '@aws-sdk/credential-provider-web-identity': 3.972.5
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/middleware-user-agent@3.972.7':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@smithy/core': 3.22.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/nested-clients@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/token-providers@3.985.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/nested-clients': 3.985.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-endpoints@3.980.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-endpoints@3.985.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.13.1
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/util-user-agent-node@3.972.5':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@aws-sdk/xml-builder@3.972.4':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.4
+      tslib: 2.8.1
+    optional: true
+
+  '@aws/lambda-invoke-store@0.2.3':
+    optional: true
+
   '@hono/node-server@1.19.9(hono@4.11.8)':
     dependencies:
       hono: 4.11.8
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+    optional: true
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+    optional: true
+
+  '@kubernetes/client-node@1.4.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 24.10.12
+      '@types/node-fetch': 2.6.13
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.5
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.19.0)
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.3.0
+      node-fetch: 2.7.0
+      openid-client: 6.8.2
+      rfc4648: 1.5.4
+      socks-proxy-agent: 8.0.5
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
@@ -420,14 +1568,388 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/core@3.22.1':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.11
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-endpoint@4.4.13':
+    dependencies:
+      '@smithy/core': 3.22.1
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-retry@4.4.30':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/node-http-handler@4.4.9':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+    optional: true
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/smithy-client@4.11.2':
+    dependencies:
+      '@smithy/core': 3.22.1
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.11
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-defaults-mode-browser@4.3.29':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-defaults-mode-node@4.2.32':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-stream@4.5.11':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/js-yaml@4.0.9':
+    optional: true
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.2.2
+      form-data: 4.0.5
+    optional: true
+
+  '@types/node@24.10.12':
+    dependencies:
+      undici-types: 7.16.0
+    optional: true
+
   '@types/node@25.2.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/stream-buffers@3.0.8':
+    dependencies:
+      '@types/node': 25.2.2
+    optional: true
 
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  agent-base@7.1.4:
+    optional: true
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -439,6 +1961,53 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  argparse@2.0.1:
+    optional: true
+
+  asynckit@0.4.0:
+    optional: true
+
+  b4a@1.7.3:
+    optional: true
+
+  bare-events@2.8.2:
+    optional: true
+
+  bare-fs@4.5.3:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.7.0(bare-events@2.8.2)
+      bare-url: 2.3.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-os@3.6.2:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.6.2
+    optional: true
+
+  bare-stream@2.7.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.23.0
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.3.2:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
 
   body-parser@2.2.2:
     dependencies:
@@ -454,6 +2023,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.13.1:
+    optional: true
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -465,6 +2037,11 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+    optional: true
 
   content-disposition@1.0.1: {}
 
@@ -489,6 +2066,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  delayed-stream@1.0.0:
+    optional: true
+
   depd@2.0.0: {}
 
   dunder-proto@1.0.1:
@@ -501,6 +2081,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -509,9 +2094,24 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+    optional: true
+
   escape-html@1.0.3: {}
 
   etag@1.8.1: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
 
   eventsource-parser@3.0.6: {}
 
@@ -559,7 +2159,15 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2:
+    optional: true
+
   fast-uri@3.1.0: {}
+
+  fast-xml-parser@5.3.4:
+    dependencies:
+      strnum: 2.1.2
+    optional: true
 
   finalhandler@2.1.1:
     dependencies:
@@ -571,6 +2179,15 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+    optional: true
 
   forwarded@0.2.0: {}
 
@@ -600,11 +2217,19 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+    optional: true
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.11.8: {}
+
+  hpagent@1.2.0:
+    optional: true
 
   http-errors@2.0.1:
     dependencies:
@@ -628,11 +2253,31 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-ws@5.0.0(ws@8.19.0):
+    dependencies:
+      ws: 8.19.0
+    optional: true
+
   jose@6.1.3: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+    optional: true
+
+  jsep@1.4.0:
+    optional: true
 
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  jsonpath-plus@10.3.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -640,7 +2285,15 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  mime-db@1.52.0:
+    optional: true
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+    optional: true
 
   mime-types@3.0.2:
     dependencies:
@@ -649,6 +2302,14 @@ snapshots:
   ms@2.1.3: {}
 
   negotiator@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+    optional: true
+
+  oauth4webapi@3.8.4:
+    optional: true
 
   object-assign@4.1.1: {}
 
@@ -662,6 +2323,12 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  openid-client@6.8.2:
+    dependencies:
+      jose: 6.1.3
+      oauth4webapi: 3.8.4
+    optional: true
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -674,6 +2341,12 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
 
   qs@6.14.1:
     dependencies:
@@ -689,6 +2362,9 @@ snapshots:
       unpipe: 1.0.0
 
   require-from-string@2.0.2: {}
+
+  rfc4648@1.5.4:
+    optional: true
 
   router@2.2.0:
     dependencies:
@@ -763,9 +2439,79 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.0.1
+      smart-buffer: 4.2.0
+    optional: true
+
   statuses@2.0.2: {}
 
+  stream-buffers@3.0.3:
+    optional: true
+
+  streamx@2.23.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  strnum@2.1.2:
+    optional: true
+
+  tar-fs@3.1.1:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.5.3
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    optional: true
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.7.3
+      fast-fifo: 1.3.2
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  text-decoder@1.2.3:
+    dependencies:
+      b4a: 1.7.3
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
   toidentifier@1.0.1: {}
+
+  tr46@0.0.3:
+    optional: true
+
+  tslib@2.8.1:
+    optional: true
 
   type-is@2.0.1:
     dependencies:
@@ -779,11 +2525,23 @@ snapshots:
 
   vary@1.1.2: {}
 
+  webidl-conversions@3.0.1:
+    optional: true
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    optional: true
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0:
+    optional: true
 
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## Summary
- add multi-backend read configuration and MCP filters
- implement local + CloudWatch + Kubernetes read backends
- aggregate results across backends with partial error reporting
- note optional SDK installs in README

## Testing
- pnpm -r build

Fixes #5