### PR TITLE
feat: add SDK auto-capture for stdout/stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,35 @@ hunch wrap --service debate-room --session room-123 -- pnpm run dev
 hunch mcp
 ```
 
+## SDK auto-capture (no CLI)
+
+Import the side-effect entrypoint to capture stdout/stderr as plain-text events:
+
+```ts
+import "hunch/auto";
+```
+
+Each line becomes a Hunch event:
+
+- `type`: `stdout` or `stderr`
+- `level`: `info` (stdout) or `error` (stderr)
+- `message`: the line content
+
+Disable or scope auto-capture in `.hunch.json`:
+
+```json
+{
+  "sdk": {
+    "enabled": false,
+    "capture_stdout": false,
+    "capture_stderr": true
+  }
+}
+```
+
+If you use `hunch wrap`, auto-capture is disabled for the wrapped process to
+avoid double-ingest.
+
 ## Monorepo layout
 
 - `packages/hunch-js` — JS SDK + CLI
@@ -91,6 +120,11 @@ For MCP usage across multiple repos, each tool accepts an optional
   "enabled": true,
   "store_dir": "logs/hunch",
   "default_service": "ais-avatars",
+  "sdk": {
+    "enabled": true,
+    "capture_stdout": true,
+    "capture_stderr": true
+  },
   "redaction": {
     "enabled": true,
     "keys": ["authorization","api_key","token","secret","password"],

--- a/packages/hunch-js/package.json
+++ b/packages/hunch-js/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./auto": {
+      "types": "./dist/auto.d.ts",
+      "import": "./dist/auto.js"
     }
   },
   "files": [

--- a/packages/hunch-js/src/auto.ts
+++ b/packages/hunch-js/src/auto.ts
@@ -1,0 +1,3 @@
+import { installAutoCapture } from "./sdk/auto.js";
+
+installAutoCapture();

--- a/packages/hunch-js/src/cli.ts
+++ b/packages/hunch-js/src/cli.ts
@@ -145,6 +145,7 @@ const handleWrap = async (argv: string[]): Promise<number> => {
       ...process.env,
       HUNCH_RUN_ID: runId,
       HUNCH_SERVICE: service,
+      HUNCH_WRAPPED: "1",
       ...(session ? { HUNCH_SESSION_ID: session } : {}),
     },
   });

--- a/packages/hunch-js/src/config.ts
+++ b/packages/hunch-js/src/config.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
-import { HunchConfig } from "./schema.js";
+import { HunchConfig, HunchSdkConfig } from "./schema.js";
 
 const DEFAULT_CONFIG: HunchConfig = {
   version: 1,
   enabled: true,
   store_dir: "logs/hunch",
   default_service: "hunch",
+  sdk: {
+    enabled: true,
+    capture_stdout: true,
+    capture_stderr: true,
+  },
   redaction: {
     enabled: true,
     keys: ["authorization", "api_key", "token", "secret", "password"],
@@ -57,10 +62,21 @@ export const findRepoRoot = (startDir: string): string => {
   }
 };
 
+const mergeSdkConfig = (
+  base: HunchSdkConfig,
+  override?: Partial<HunchSdkConfig>,
+): HunchSdkConfig => {
+  return {
+    ...base,
+    ...(override ?? {}),
+  };
+};
+
 const mergeConfig = (base: HunchConfig, override: Partial<HunchConfig>): HunchConfig => {
   return {
     ...base,
     ...override,
+    sdk: mergeSdkConfig(base.sdk, override.sdk),
     redaction: {
       ...base.redaction,
       ...(override.redaction ?? {}),

--- a/packages/hunch-js/src/index.ts
+++ b/packages/hunch-js/src/index.ts
@@ -1,2 +1,3 @@
 export { emit } from "./sdk/emit.js";
+export { installAutoCapture } from "./sdk/auto.js";
 export type { HunchEvent, HunchLevel, HunchConfig } from "./schema.js";

--- a/packages/hunch-js/src/schema.ts
+++ b/packages/hunch-js/src/schema.ts
@@ -8,6 +8,12 @@ export type HunchSource = {
   line?: number;
 };
 
+export type HunchSdkConfig = {
+  enabled: boolean;
+  capture_stdout: boolean;
+  capture_stderr: boolean;
+};
+
 export type HunchEvent = {
   id: string;
   ts: string;
@@ -29,6 +35,7 @@ export type HunchConfig = {
   enabled: boolean;
   store_dir: string;
   default_service: string;
+  sdk: HunchSdkConfig;
   redaction: {
     enabled: boolean;
     keys: string[];

--- a/packages/hunch-js/src/sdk/auto.ts
+++ b/packages/hunch-js/src/sdk/auto.ts
@@ -1,0 +1,136 @@
+import { emit } from "./emit.js";
+import { loadConfig } from "../config.js";
+import { HunchEvent } from "../schema.js";
+
+type StopHandle = { stop: () => void };
+
+type WriteTarget = {
+  stream: NodeJS.WriteStream;
+  type: "stdout" | "stderr";
+  level: HunchEvent["level"];
+};
+
+type WriteFn = typeof process.stdout.write;
+
+type CaptureState = {
+  stop: () => void;
+};
+
+let installed: CaptureState | null = null;
+
+const shouldCapture = (): boolean => {
+  if (process.env.HUNCH_WRAPPED === "1") {
+    return false;
+  }
+  const { config } = loadConfig();
+  if (!config.enabled) {
+    return false;
+  }
+  if (!config.sdk.enabled) {
+    return false;
+  }
+  return config.sdk.capture_stdout || config.sdk.capture_stderr;
+};
+
+const flushLine = (target: WriteTarget, line: string): void => {
+  if (!line.trim()) {
+    return;
+  }
+  void emit({
+    type: target.type,
+    level: target.level,
+    message: line,
+    source: { kind: target.type },
+  });
+};
+
+const installCaptureFor = (
+  target: WriteTarget,
+  bufferRef: { value: string },
+): WriteFn => {
+  const original = target.stream.write.bind(target.stream);
+  const patched: WriteFn = (chunk: any, encoding?: any, cb?: any) => {
+    const result = original(chunk, encoding as any, cb as any);
+    const resolvedEncoding: BufferEncoding =
+      typeof encoding === "string" ? (encoding as BufferEncoding) : "utf8";
+    const text = Buffer.isBuffer(chunk)
+      ? chunk.toString(resolvedEncoding)
+      : String(chunk);
+    bufferRef.value += text;
+    const lines = bufferRef.value.split(/\r?\n/);
+    bufferRef.value = lines.pop() ?? "";
+    for (const line of lines) {
+      flushLine(target, line);
+    }
+    return result;
+  };
+  target.stream.write = patched as typeof target.stream.write;
+  return original;
+};
+
+export const installAutoCapture = (): StopHandle => {
+  if (installed) {
+    return installed;
+  }
+
+  if (!shouldCapture()) {
+    const noOp = { stop: () => {} };
+    installed = noOp;
+    return noOp;
+  }
+
+  const buffers = {
+    stdout: { value: "" },
+    stderr: { value: "" },
+  };
+
+  const originals: Partial<Record<"stdout" | "stderr", WriteFn>> = {};
+
+  const { config } = loadConfig();
+
+  if (config.sdk.capture_stdout) {
+    originals.stdout = installCaptureFor(
+      { stream: process.stdout, type: "stdout", level: "info" },
+      buffers.stdout,
+    );
+  }
+  if (config.sdk.capture_stderr) {
+    originals.stderr = installCaptureFor(
+      { stream: process.stderr, type: "stderr", level: "error" },
+      buffers.stderr,
+    );
+  }
+
+  const flush = () => {
+    if (config.sdk.capture_stdout && buffers.stdout.value.trim()) {
+      flushLine({ stream: process.stdout, type: "stdout", level: "info" }, buffers.stdout.value);
+      buffers.stdout.value = "";
+    }
+    if (config.sdk.capture_stderr && buffers.stderr.value.trim()) {
+      flushLine({ stream: process.stderr, type: "stderr", level: "error" }, buffers.stderr.value);
+      buffers.stderr.value = "";
+    }
+  };
+
+  const beforeExit = () => flush();
+
+  process.on("beforeExit", beforeExit);
+  process.on("exit", beforeExit);
+
+  const stop = () => {
+    flush();
+    if (originals.stdout) {
+      process.stdout.write = originals.stdout as typeof process.stdout.write;
+    }
+    if (originals.stderr) {
+      process.stderr.write = originals.stderr as typeof process.stderr.write;
+    }
+    process.off("beforeExit", beforeExit);
+    process.off("exit", beforeExit);
+    installed = null;
+  };
+
+  const handle = { stop };
+  installed = handle;
+  return handle;
+};

--- a/packages/hunch-js/test/auto-capture.test.js
+++ b/packages/hunch-js/test/auto-capture.test.js
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { execSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const distAuto = path.join(repoRoot, "dist", "auto.js");
+const distIndex = path.join(repoRoot, "dist", "index.js");
+
+if (!fs.existsSync(distAuto) || !fs.existsSync(distIndex)) {
+  execSync("pnpm run build", { cwd: repoRoot, stdio: "inherit" });
+}
+
+const runNode = (script, envOverrides = {}) => {
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: repoRoot,
+    env: { ...process.env, ...envOverrides },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+};
+
+const readEvents = (storeDir, service, runId) => {
+  const dateSegment = new Date().toISOString().slice(0, 10);
+  const filePath = path.join(storeDir, service, dateSegment, `${runId}.jsonl`);
+  const raw = fs.readFileSync(filePath, "utf8").trim();
+  if (!raw) {
+    return [];
+  }
+  return raw.split(/\r?\n/).map((line) => JSON.parse(line));
+};
+
+test("auto-captures stdout and stderr lines", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hunch-auto-"));
+  const storeDir = path.join(tempDir, "store");
+  const service = "auto-capture";
+  const runId = "run-stdout-stderr";
+
+  runNode(
+    `
+      import { pathToFileURL } from "node:url";
+      const autoUrl = pathToFileURL(process.env.HUNCH_AUTO_PATH).href;
+      await import(autoUrl);
+      process.stdout.write("hello stdout\\n");
+      process.stderr.write("oops stderr\\n");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    `,
+    {
+      HUNCH_AUTO_PATH: distAuto,
+      HUNCH_DIR: storeDir,
+      HUNCH_SERVICE: service,
+      HUNCH_RUN_ID: runId,
+    },
+  );
+
+  const events = readEvents(storeDir, service, runId);
+  assert.ok(
+    events.some(
+      (event) =>
+        event.message === "hello stdout" &&
+        event.type === "stdout" &&
+        event.level === "info" &&
+        event.source?.kind === "stdout",
+    ),
+    "expected stdout event",
+  );
+  assert.ok(
+    events.some(
+      (event) =>
+        event.message === "oops stderr" &&
+        event.type === "stderr" &&
+        event.level === "error" &&
+        event.source?.kind === "stderr",
+    ),
+    "expected stderr event",
+  );
+});
+
+test("respects sdk.enabled=false in config", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hunch-auto-"));
+  const storeDir = path.join(tempDir, "store");
+  const service = "auto-disabled";
+  const runId = "run-disabled";
+  const configPath = path.join(tempDir, ".hunch.json");
+
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        enabled: true,
+        store_dir: storeDir,
+        default_service: service,
+        sdk: { enabled: false },
+      },
+      null,
+      2,
+    ),
+  );
+
+  runNode(
+    `
+      import { pathToFileURL } from "node:url";
+      const autoUrl = pathToFileURL(process.env.HUNCH_AUTO_PATH).href;
+      await import(autoUrl);
+      process.stdout.write("should-not-capture\\n");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    `,
+    {
+      HUNCH_AUTO_PATH: distAuto,
+      HUNCH_CONFIG_PATH: configPath,
+      HUNCH_SERVICE: service,
+      HUNCH_RUN_ID: runId,
+    },
+  );
+
+  const dateSegment = new Date().toISOString().slice(0, 10);
+  const filePath = path.join(storeDir, service, dateSegment, `${runId}.jsonl`);
+  assert.ok(!fs.existsSync(filePath), "expected no captured events");
+});
+
+test("flushes partial lines on stop()", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "hunch-auto-"));
+  const storeDir = path.join(tempDir, "store");
+  const service = "auto-flush";
+  const runId = "run-partial";
+
+  runNode(
+    `
+      import { pathToFileURL } from "node:url";
+      const indexUrl = pathToFileURL(process.env.HUNCH_INDEX_PATH).href;
+      const { installAutoCapture } = await import(indexUrl);
+      const handle = installAutoCapture();
+      process.stdout.write("partial line");
+      handle.stop();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    `,
+    {
+      HUNCH_INDEX_PATH: distIndex,
+      HUNCH_DIR: storeDir,
+      HUNCH_SERVICE: service,
+      HUNCH_RUN_ID: runId,
+    },
+  );
+
+  const events = readEvents(storeDir, service, runId);
+  assert.ok(
+    events.some((event) => event.message === "partial line" && event.type === "stdout"),
+    "expected partial line to be flushed",
+  );
+});


### PR DESCRIPTION
## Summary
- add SDK auto-capture via side-effect import (hunch/auto)
- add sdk config toggles and wrap guard to avoid double capture
- add tests for stdout/stderr capture, disablement, and flush

## Testing
- pnpm test

Fixes #7