### PR TITLE
fix: use npm provenance for oidc publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Enable corepack
         run: corepack enable

--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -20,7 +20,7 @@ const run = (cmd, args, cwd = root) => {
 run("pnpm", ["-r", "build"]);
 
 for (const pkg of jsPackages) {
-  run("npm", ["publish", "--access", "public"], pkg.dir);
+  run("npm", ["publish", "--access", "public", "--provenance"], pkg.dir);
 }
 
 run("python", ["-m", "build"], pyDir);


### PR DESCRIPTION
## Summary
- add npm `--provenance` to publish command to trigger OIDC auth
- set `registry-url` in setup-node for npm config

## Testing
- not run (CI workflow change)
