### PR TITLE
fix: add repo metadata for npm provenance

### DIFF
--- a/packages/guck-cli/package.json
+++ b/packages/guck-cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Guck telemetry capture and MCP",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tillkolter/guck-mcp.git"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-core/package.json
+++ b/packages/guck-core/package.json
@@ -4,7 +4,7 @@
   "description": "Core utilities and types for Guck telemetry",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tillkolter/guck-mcp.git"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-js/package.json
+++ b/packages/guck-js/package.json
@@ -4,7 +4,7 @@
   "description": "Guck JS SDK",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tillkolter/guck-mcp.git"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-mcp/package.json
+++ b/packages/guck-mcp/package.json
@@ -4,7 +4,7 @@
   "description": "MCP server for Guck telemetry",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tillkolter/guck-mcp.git"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- add repository metadata to published JS packages so npm provenance validation succeeds

## Testing
- not run (metadata change only)
