### PR TITLE
fix: add npm global install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Guck is designed to be:
 ```sh
 pnpm add -g @guckdev/cli
 # or
+npm install -g @guckdev/cli
+# or
 npx @guckdev/cli
 ```
 


### PR DESCRIPTION
## Summary
- add an npm global install example to the README

## Testing
- not run (docs-only)
