### PR TITLE
docs: refocus quick start on MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,33 @@ If you previously installed `guck-cli`, switch to `@guckdev/cli`.
 
 ## Quick start
 
-```sh
-guck init
-guck wrap --service debate-room --session room-123 -- pnpm run dev
-# in another terminal
-guck mcp
+1) Configure MCP (Codex/Claude/Copilot):
+
+```json
+{
+  "mcpServers": {
+    "guck": {
+      "command": "guck",
+      "args": ["mcp"],
+      "env": {
+        "GUCK_CONFIG_PATH": "/path/to/.guck.json"
+      }
+    }
+  }
+}
 ```
+
+2) Drop‑in log capture (JS) — use auto‑capture, emit(), or both:
+
+```ts
+import "@guckdev/sdk/auto";
+import { emit } from "@guckdev/sdk";
+
+emit({ message: "hello from app" });
+```
+
+3) Run your app; the MCP client will spawn `guck mcp` and logs are queryable via
+`guck.stats` / `guck.search`.
 
 ## Monorepo layout
 


### PR DESCRIPTION
## Summary
- move Quick start to MCP client config + JS drop-in logging snippet
- remove wrap-based flow from the get-started path

## Testing
- not run (docs-only)

Fixes #39