### PR TITLE
feat: add Vite dev ingest proxy and browser dev guards

### DIFF
--- a/packages/guck-vite/package.json
+++ b/packages/guck-vite/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "25.2.2",
+    "typescript": "5.6.3",
     "vite": "^5.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,19 +17,19 @@ importers:
     devDependencies:
       '@semantic-release/commit-analyzer':
         specifier: ^12.0.0
-        version: 12.0.0(semantic-release@24.2.9)
+        version: 12.0.0(semantic-release@24.2.9(typescript@5.6.3))
       '@semantic-release/exec':
         specifier: ^6.0.0
-        version: 6.0.3(semantic-release@24.2.9)
+        version: 6.0.3(semantic-release@24.2.9(typescript@5.6.3))
       '@semantic-release/github':
         specifier: ^10.0.0
-        version: 10.3.5(semantic-release@24.2.9)
+        version: 10.3.5(semantic-release@24.2.9(typescript@5.6.3))
       '@semantic-release/release-notes-generator':
         specifier: ^13.0.0
-        version: 13.0.0(semantic-release@24.2.9)
+        version: 13.0.0(semantic-release@24.2.9(typescript@5.6.3))
       semantic-release:
         specifier: ^24.0.0
-        version: 24.2.9
+        version: 24.2.9(typescript@5.6.3)
 
   packages/guck-browser:
     devDependencies:
@@ -97,6 +97,9 @@ importers:
       '@types/node':
         specifier: 25.2.2
         version: 25.2.2
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5.4.0
         version: 5.4.21(@types/node@25.2.2)
@@ -2520,6 +2523,11 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -3591,7 +3599,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/commit-analyzer@12.0.0(semantic-release@24.2.9)':
+  '@semantic-release/commit-analyzer@12.0.0(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       conventional-changelog-angular: 7.0.0
       conventional-commits-filter: 4.0.0
@@ -3600,11 +3608,11 @@ snapshots:
       import-from-esm: 1.3.4
       lodash-es: 4.17.23
       micromatch: 4.0.8
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.9)':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       conventional-changelog-angular: 8.1.0
       conventional-changelog-writer: 8.2.0
@@ -3614,7 +3622,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.17.23
       micromatch: 4.0.8
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3622,7 +3630,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@6.0.3(semantic-release@24.2.9)':
+  '@semantic-release/exec@6.0.3(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -3630,11 +3638,11 @@ snapshots:
       execa: 5.1.1
       lodash: 4.17.23
       parse-json: 5.2.0
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@10.3.5(semantic-release@24.2.9)':
+  '@semantic-release/github@10.3.5(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       '@octokit/core': 6.1.6
       '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.6)
@@ -3651,12 +3659,12 @@ snapshots:
       lodash-es: 4.17.23
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@11.0.6(semantic-release@24.2.9)':
+  '@semantic-release/github@11.0.6(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 13.2.1(@octokit/core@7.0.6)
@@ -3672,13 +3680,13 @@ snapshots:
       lodash-es: 4.17.23
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
       tinyglobby: 0.2.15
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@12.0.2(semantic-release@24.2.9)':
+  '@semantic-release/npm@12.0.2(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
@@ -3691,11 +3699,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 9.0.1
       registry-auth-token: 5.1.1
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
       semver: 7.7.4
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@13.0.0(semantic-release@24.2.9)':
+  '@semantic-release/release-notes-generator@13.0.0(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       conventional-changelog-angular: 7.0.0
       conventional-changelog-writer: 7.0.1
@@ -3707,11 +3715,11 @@ snapshots:
       into-stream: 7.0.0
       lodash-es: 4.17.23
       read-pkg-up: 11.0.0
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.9)':
+  '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       conventional-changelog-angular: 8.1.0
       conventional-changelog-writer: 8.2.0
@@ -3723,7 +3731,7 @@ snapshots:
       into-stream: 7.0.0
       lodash-es: 4.17.23
       read-package-up: 11.0.0
-      semantic-release: 24.2.9
+      semantic-release: 24.2.9(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4385,12 +4393,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@9.0.0:
+  cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.6.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5357,15 +5367,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  semantic-release@24.2.9:
+  semantic-release@24.2.9(typescript@5.6.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.9)
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.9(typescript@5.6.3))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.6(semantic-release@24.2.9)
-      '@semantic-release/npm': 12.0.2(semantic-release@24.2.9)
-      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.9)
+      '@semantic-release/github': 11.0.6(semantic-release@24.2.9(typescript@5.6.3))
+      '@semantic-release/npm': 12.0.2(semantic-release@24.2.9(typescript@5.6.3))
+      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.9(typescript@5.6.3))
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.0
+      cosmiconfig: 9.0.0(typescript@5.6.3)
       debug: 4.4.3
       env-ci: 11.2.0
       execa: 9.6.1
@@ -5677,6 +5687,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typescript@5.6.3: {}
 
   uglify-js@3.19.3:
     optional: true


### PR DESCRIPTION
## Summary
- add `@guckdev/vite` dev-server plugin to proxy `/guck/emit` to MCP ingest and inject config path server-side
- make browser SDK dev-only with local endpoint guard and remove config path header
- update docs for Vite drop-in and remove internal hostnames
- make guck-vite build use `pnpm dlx` typescript to avoid global `tsc` in publish

## Testing
- `pnpm --package=typescript@5.6.3 dlx tsc -p packages/guck-vite/tsconfig.json`
- `node --test packages/guck-vite/test/plugin.test.js`

## Notes
- Not run: `pnpm -r build`, `pnpm -r test`, `pnpm run spec:check`
