### PR TITLE
fix: publish guck-vite in release pipeline

### DIFF
--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -9,6 +9,7 @@ const jsPackages = [
   { name: "@guckdev/mcp", dir: path.join(root, "packages", "guck-mcp") },
   { name: "@guckdev/browser", dir: path.join(root, "packages", "guck-browser") },
   { name: "@guckdev/cli", dir: path.join(root, "packages", "guck-cli") },
+  { name: "@guckdev/vite", dir: path.join(root, "packages", "guck-vite") },
 ];
 
 const run = (cmd, args, cwd = root) => {

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -50,3 +50,4 @@ updateJsonVersion(path.join(root, "packages", "guck-cli", "package.json"));
 updateJsonVersion(path.join(root, "packages", "guck-core", "package.json"));
 updateJsonVersion(path.join(root, "packages", "guck-mcp", "package.json"));
 updateJsonVersion(path.join(root, "packages", "guck-browser", "package.json"));
+updateJsonVersion(path.join(root, "packages", "guck-vite", "package.json"));


### PR DESCRIPTION
## Summary
- include `@guckdev/vite` in release publish script
- include `guck-vite` in version sync for releases

## Testing
- not run (script changes only)
