### PR TITLE
chore: parallelize npm publish stages

### DIFF
--- a/scripts/release-publish.mjs
+++ b/scripts/release-publish.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
@@ -12,17 +12,92 @@ const jsPackages = [
   { name: "@guckdev/vite", dir: path.join(root, "packages", "guck-vite") },
 ];
 
-const run = (cmd, args, cwd = root) => {
-  const result = spawnSync(cmd, args, { cwd, stdio: "inherit" });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+const formatCommand = (cmd, args) => [cmd, ...args].join(" ");
+
+const spawnCommand = (cmd, args, cwd = root) => {
+  const child = spawn(cmd, args, { cwd, stdio: "inherit" });
+  const promise = new Promise((resolve, reject) => {
+    child.on("error", (err) => reject(err));
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const reason = code !== null ? `exit ${code}` : `signal ${signal}`;
+      reject(new Error(`${formatCommand(cmd, args)} failed (${reason})`));
+    });
+  });
+  return { child, promise, cmd, args };
+};
+
+const runCommand = async (cmd, args, cwd = root) => {
+  const { promise } = spawnCommand(cmd, args, cwd);
+  await promise;
+};
+
+const runBatch = async (commands) => {
+  const spawned = commands.map((command) =>
+    spawnCommand(command.cmd, command.args, command.cwd),
+  );
+  let aborted = false;
+  const guarded = spawned.map((spawnedCommand) =>
+    spawnedCommand.promise.catch((err) => {
+      if (!aborted) {
+        aborted = true;
+        for (const other of spawned) {
+          if (other !== spawnedCommand && other.child.exitCode === null) {
+            other.child.kill("SIGTERM");
+          }
+        }
+      }
+      throw err;
+    }),
+  );
+
+  try {
+    await Promise.all(guarded);
+  } catch (err) {
+    await Promise.allSettled(guarded);
+    throw err;
   }
 };
 
-run("pnpm", ["-r", "build"]);
+const main = async () => {
+  await runCommand("pnpm", ["-r", "build"]);
 
-for (const pkg of jsPackages) {
-  run("npm", ["publish", "--access", "public", "--provenance"], pkg.dir);
-}
+  await runBatch([
+    {
+      cmd: "npm",
+      args: ["publish", "--access", "public", "--provenance"],
+      cwd: jsPackages[0].dir,
+    },
+  ]);
 
-run("python", ["-m", "build"], pyDir);
+  await runBatch([
+    {
+      cmd: "npm",
+      args: ["publish", "--access", "public", "--provenance"],
+      cwd: jsPackages[1].dir,
+    },
+    {
+      cmd: "npm",
+      args: ["publish", "--access", "public", "--provenance"],
+      cwd: jsPackages[2].dir,
+    },
+  ]);
+
+  await runBatch([
+    {
+      cmd: "npm",
+      args: ["publish", "--access", "public", "--provenance"],
+      cwd: jsPackages[3].dir,
+    },
+  ]);
+
+  await runCommand("python", ["-m", "build"], pyDir);
+};
+
+main().catch((err) => {
+  console.error(err?.stack ?? err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- parallelize npm publishes while preserving dependency order
- add fail-fast batch runner with interleaved logs

## Testing
- not run (not requested)

Fixes #17