### PR TITLE
fix: split publish into workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ github.token }}
+    outputs:
+      released: ${{ steps.release_tag.outputs.released }}
+      version: ${{ steps.release_tag.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,31 +40,225 @@ jobs:
       - name: Upgrade npm (OIDC support)
         run: npm install -g npm@11.5.1
 
+      - name: Install JS deps (pnpm install)
+        run: pnpm install --frozen-lockfile
+
+      - name: Release
+        run: pnpm exec semantic-release
+
+      - name: Resolve release tag
+        id: release_tag
+        run: |
+          git fetch --tags --force
+          tag="$(git tag --points-at HEAD | grep -E '^v[0-9]' | head -n 1 || true)"
+          if [ -z "$tag" ]; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+
+  publish-core:
+    name: "Publish @guckdev/core"
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.12.3 --activate
+
+      - name: Upgrade npm (OIDC support)
+        run: npm install -g npm@11.5.1
+
+      - name: Install JS deps (pnpm install)
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync release version
+        run: node scripts/release-prepare.mjs "${RELEASE_VERSION}"
+
+      - name: Publish @guckdev/core
+        run: npm publish --access public --provenance
+        working-directory: packages/guck-core
+
+  publish-sdk:
+    name: "Publish @guckdev/sdk"
+    needs: [release, publish-core]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.12.3 --activate
+
+      - name: Upgrade npm (OIDC support)
+        run: npm install -g npm@11.5.1
+
+      - name: Install JS deps (pnpm install)
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync release version
+        run: node scripts/release-prepare.mjs "${RELEASE_VERSION}"
+
+      - name: Publish @guckdev/sdk
+        run: npm publish --access public --provenance
+        working-directory: packages/guck-js
+
+  publish-mcp:
+    name: "Publish @guckdev/mcp"
+    needs: [release, publish-core]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.12.3 --activate
+
+      - name: Upgrade npm (OIDC support)
+        run: npm install -g npm@11.5.1
+
+      - name: Install JS deps (pnpm install)
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync release version
+        run: node scripts/release-prepare.mjs "${RELEASE_VERSION}"
+
+      - name: Publish @guckdev/mcp
+        run: npm publish --access public --provenance
+        working-directory: packages/guck-mcp
+
+  publish-cli:
+    name: "Publish @guckdev/cli"
+    needs: [release, publish-sdk, publish-mcp]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Install pnpm
+        run: corepack prepare pnpm@9.12.3 --activate
+
+      - name: Upgrade npm (OIDC support)
+        run: npm install -g npm@11.5.1
+
+      - name: Install JS deps (pnpm install)
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync release version
+        run: node scripts/release-prepare.mjs "${RELEASE_VERSION}"
+
+      - name: Publish @guckdev/cli
+        run: npm publish --access public --provenance
+        working-directory: packages/guck-cli
+
+  publish-py:
+    name: "Publish guck-sdk (PyPI)"
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install JS deps (pnpm install)
-        run: pnpm install --frozen-lockfile
-
       - name: Install Python build deps
         run: python -m pip install --upgrade build
 
-      - name: Release
-        run: pnpm exec semantic-release
+      - name: Sync release version
+        run: node scripts/release-prepare.mjs "${RELEASE_VERSION}"
 
-      - name: Check for PyPI artifacts
-        id: pypi_dist
-        run: |
-          if [ -d packages/guck-py/dist ] && [ "$(ls -A packages/guck-py/dist)" ]; then
-            echo "has_dist=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_dist=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Build Python package
+        run: python -m build
+        working-directory: packages/guck-py
 
       - name: Publish to PyPI (trusted publishing)
-        if: steps.pypi_dist.outputs.has_dist == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/guck-py/dist

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -8,7 +8,6 @@ module.exports = {
       "@semantic-release/exec",
       {
         prepareCmd: "node scripts/release-prepare.mjs ${nextRelease.version}",
-        publishCmd: "node scripts/release-publish.mjs ${nextRelease.version}",
       },
     ],
     "@semantic-release/github",


### PR DESCRIPTION
## Summary
- move npm publishes into separate workflow jobs with dependency ordering
- move PyPI publish into its own job and gate on release creation
- remove semantic-release publish command so CI owns publishing

## Testing
- not run (workflow change only)

Fixes #51