### PR TITLE
feat: EKS SDK auth for kubeconfig-based K8s backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,31 @@ If you need a custom location, set `GUCK_DIR` on the **server** process
 
 Remote backends (CloudWatch/K8s) require optional SDK installs; install only if you use them.
 
+Kubernetes (EKS) backend example (SDK auth; no aws/kubectl exec):
+
+```json
+{
+  "read": {
+    "backend": "multi",
+    "backends": [
+      {
+        "type": "k8s",
+        "id": "k8s-api",
+        "namespace": "avatars",
+        "selector": "app.kubernetes.io/component=api,app.kubernetes.io/instance=avatars",
+        "container": "avatars",
+        "clusterName": "eks1-euc1-stg-bi",
+        "region": "eu-central-1",
+        "profile": "business-innovation-dev.admin"
+      }
+    ]
+  }
+}
+```
+
+If `clusterName` and `region` are set (or your kubeconfig user uses `aws eks get-token`),
+Guck uses the AWS SDK to fetch tokens and ignores kubeconfig exec plugins.
+
 ### JS SDK auto-capture (stdout/stderr)
 
 The JS SDK can patch `process.stdout` and `process.stderr` to emit Guck events.

--- a/packages/guck-core/package.json
+++ b/packages/guck-core/package.json
@@ -33,8 +33,13 @@
   },
   "optionalDependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.985.0",
+    "@aws-sdk/client-eks": "3.985.0",
+    "@aws-sdk/client-sts": "3.985.0",
     "@aws-sdk/credential-providers": "3.985.0",
-    "@kubernetes/client-node": "1.4.0"
+    "@kubernetes/client-node": "1.4.0",
+    "@smithy/hash-node": "4.2.8",
+    "@smithy/protocol-http": "5.3.8",
+    "@smithy/signature-v4": "5.3.8"
   },
   "devDependencies": {
     "@types/node": "25.2.2"

--- a/packages/guck-core/src/schema.ts
+++ b/packages/guck-core/src/schema.ts
@@ -76,6 +76,9 @@ export type GuckK8sReadBackendConfig = {
   context?: string;
   container?: string;
   service?: string;
+  clusterName?: string;
+  region?: string;
+  profile?: string;
 };
 
 export type GuckReadBackendConfig =

--- a/packages/guck-core/src/store/backends/eks-auth.ts
+++ b/packages/guck-core/src/store/backends/eks-auth.ts
@@ -1,0 +1,231 @@
+import { createRequire } from "node:module";
+
+const requireModule = createRequire(import.meta.url);
+
+const DEFAULT_EKS_TOKEN_TTL_SECONDS = 14 * 60;
+
+type EksClusterInfo = {
+  endpoint: string;
+  certificateAuthorityData?: string;
+};
+
+type EksTokenResult = {
+  token: string;
+  expiresAtMs: number;
+};
+
+type EksAuthOptions = {
+  clusterName: string;
+  region: string;
+  profile?: string;
+  credentials?: unknown;
+  expiresInSeconds?: number;
+  now?: Date;
+};
+
+const loadEksSdk = (): {
+  EKSClient: new (config: { region: string; credentials?: unknown }) => {
+    send: (command: unknown) => Promise<{ cluster?: { endpoint?: string; certificateAuthority?: { data?: string } } }>;
+  };
+  DescribeClusterCommand: new (input: { name: string }) => unknown;
+} => {
+  try {
+    return requireModule("@aws-sdk/client-eks");
+  } catch {
+    throw new Error(
+      "EKS auth requires @aws-sdk/client-eks. Install it to enable EKS token auth.",
+    );
+  }
+};
+
+const loadStsSdk = (): {
+  STSClient: new (config: { region: string; credentials?: unknown }) => {
+    config: { credentials: unknown };
+  };
+} => {
+  try {
+    return requireModule("@aws-sdk/client-sts");
+  } catch {
+    throw new Error(
+      "EKS auth requires @aws-sdk/client-sts. Install it to enable EKS token auth.",
+    );
+  }
+};
+
+const loadSignatureV4 = (): { SignatureV4: new (input: { credentials: unknown; region: string; service: string; sha256: unknown }) => { presign: (req: unknown, opts: { expiresIn: number; signingDate?: Date }) => Promise<unknown> } } => {
+  try {
+    return requireModule("@smithy/signature-v4");
+  } catch {
+    throw new Error(
+      "EKS auth requires @smithy/signature-v4. Install it to enable EKS token auth.",
+    );
+  }
+};
+
+const loadProtocolHttp = (): { HttpRequest: new (input: { protocol: string; method: string; hostname: string; path: string; query: Record<string, string>; headers: Record<string, string> }) => unknown } => {
+  try {
+    return requireModule("@smithy/protocol-http");
+  } catch {
+    throw new Error(
+      "EKS auth requires @smithy/protocol-http. Install it to enable EKS token auth.",
+    );
+  }
+};
+
+type HashInstance = {
+  update: (data: string | Uint8Array, encoding?: string) => void;
+  digest: () => Promise<Uint8Array>;
+};
+
+type HashCtor = new (
+  algorithmIdentifier: string,
+  secret?: string | Uint8Array,
+) => HashInstance;
+
+const loadHash = (): { Hash: HashCtor } => {
+  try {
+    return requireModule("@smithy/hash-node");
+  } catch {
+    throw new Error(
+      "EKS auth requires @smithy/hash-node. Install it to enable EKS token auth.",
+    );
+  }
+};
+
+const loadCredentialProviders = (): { fromIni: (input: { profile: string }) => unknown } => {
+  try {
+    return requireModule("@aws-sdk/credential-providers");
+  } catch {
+    throw new Error(
+      "EKS auth requires @aws-sdk/credential-providers when using profile override.",
+    );
+  }
+};
+
+const resolveCredentials = (profile?: string, credentials?: unknown): unknown => {
+  if (credentials) {
+    return credentials;
+  }
+  if (!profile) {
+    return undefined;
+  }
+  return loadCredentialProviders().fromIni({ profile });
+};
+
+const toBase64Url = (value: string): string => {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+};
+
+const formatUrl = (request: {
+  protocol?: string;
+  hostname?: string;
+  path?: string;
+  query?: Record<string, string | number | Array<string | number> | undefined>;
+}): string => {
+  const protocol = request.protocol ? (request.protocol.endsWith(":") ? request.protocol : `${request.protocol}:`) : "https:";
+  const hostname = request.hostname ?? "";
+  const path = request.path ?? "/";
+  const params = new URLSearchParams();
+  const query = request.query ?? {};
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        params.append(key, String(entry));
+      }
+    } else {
+      params.append(key, String(value));
+    }
+  }
+  const queryString = params.toString();
+  return `${protocol}//${hostname}${path}${queryString ? `?${queryString}` : ""}`;
+};
+
+export const fetchEksClusterInfo = async (
+  options: Pick<EksAuthOptions, "clusterName" | "region" | "profile" | "credentials">,
+): Promise<EksClusterInfo> => {
+  const { EKSClient, DescribeClusterCommand } = loadEksSdk();
+  const resolvedCredentials = resolveCredentials(options.profile, options.credentials);
+  const client = new EKSClient({ region: options.region, credentials: resolvedCredentials });
+  const response = await client.send(new DescribeClusterCommand({ name: options.clusterName }));
+  const cluster = response.cluster;
+  if (!cluster?.endpoint) {
+    throw new Error(`EKS cluster ${options.clusterName} has no endpoint.`);
+  }
+  return {
+    endpoint: cluster.endpoint,
+    certificateAuthorityData: cluster.certificateAuthority?.data,
+  };
+};
+
+export const buildEksToken = async (options: EksAuthOptions): Promise<EksTokenResult> => {
+  const { SignatureV4 } = loadSignatureV4();
+  const { HttpRequest } = loadProtocolHttp();
+  const { Hash } = loadHash();
+  class Sha256 {
+    private hash: HashInstance;
+    constructor(secret?: string | Uint8Array) {
+      this.hash = new Hash("sha256", secret);
+    }
+    update(data: string | Uint8Array): void {
+      this.hash.update(data);
+    }
+    digest(): Promise<Uint8Array> {
+      return this.hash.digest();
+    }
+  }
+
+  const resolvedCredentials = resolveCredentials(options.profile, options.credentials);
+  const { STSClient } = loadStsSdk();
+  const stsClient = new STSClient({
+    region: options.region,
+    credentials: resolvedCredentials,
+  });
+
+  const signer = new SignatureV4({
+    credentials: stsClient.config.credentials,
+    region: options.region,
+    service: "sts",
+    sha256: Sha256,
+  });
+
+  const hostname = `sts.${options.region}.amazonaws.com`;
+  const request = new HttpRequest({
+    protocol: "https:",
+    method: "GET",
+    hostname,
+    path: "/",
+    query: {
+      Action: "GetCallerIdentity",
+      Version: "2011-06-15",
+    },
+    headers: {
+      host: hostname,
+      "x-k8s-aws-id": options.clusterName,
+    },
+  });
+
+  const expiresInSeconds = options.expiresInSeconds ?? DEFAULT_EKS_TOKEN_TTL_SECONDS;
+  const now = options.now ?? new Date();
+  const signed = (await signer.presign(request, {
+    expiresIn: expiresInSeconds,
+    signingDate: now,
+  })) as {
+    protocol?: string;
+    hostname?: string;
+    path?: string;
+    query?: Record<string, string | number | Array<string | number>>;
+  };
+
+  const url = formatUrl(signed);
+  return {
+    token: `k8s-aws-v1.${toBase64Url(url)}`,
+    expiresAtMs: now.getTime() + expiresInSeconds * 1000,
+  };
+};

--- a/packages/guck-core/src/store/backends/k8s.ts
+++ b/packages/guck-core/src/store/backends/k8s.ts
@@ -9,9 +9,11 @@ import {
 } from "../../schema.js";
 import { eventMatches, normalizeLevel } from "../filters.js";
 import { normalizeTimestamp, parseTimeInput } from "../time.js";
+import { buildEksToken, fetchEksClusterInfo } from "./eks-auth.js";
 import { ReadBackend, SearchResult, SessionsResult, StatsResult } from "./types.js";
 
 type K8sClient = {
+  api?: unknown;
   listNamespacedPod: (...args: unknown[]) => Promise<{
     body: { items: Array<{ metadata?: { name?: string } }> };
   }>;
@@ -192,15 +194,56 @@ const toEvent = (
 
 const requireModule = createRequire(import.meta.url);
 
-const loadClient = (context?: string): K8sClient => {
-  let module: {
-    KubeConfig: new () => {
-      loadFromDefault: () => void;
-      setCurrentContext: (ctx: string) => void;
-      makeApiClient: (api: unknown) => unknown;
-    };
-    CoreV1Api: new () => unknown;
-  };
+type KubeConfigUserExec = {
+  command?: string;
+  args?: string[];
+  env?: Array<{ name?: string; value?: string }>;
+};
+
+type KubeConfigUser = {
+  name?: string;
+  exec?: KubeConfigUserExec;
+};
+
+type KubeConfigContext = {
+  name?: string;
+  cluster?: string;
+  user?: string;
+  namespace?: string;
+};
+
+type KubeConfigCluster = {
+  name?: string;
+  server?: string;
+  caData?: string;
+  skipTLSVerify?: boolean;
+};
+
+type KubeConfigLike = {
+  loadFromDefault: () => void;
+  setCurrentContext: (ctx: string) => void;
+  makeApiClient: (api: unknown) => unknown;
+  loadFromOptions?: (opts: {
+    clusters: KubeConfigCluster[];
+    users: Array<{ name: string; token: string }>;
+    contexts: KubeConfigContext[];
+    currentContext: string;
+  }) => void;
+  getCurrentContext?: () => string;
+  getCurrentCluster?: () => KubeConfigCluster | undefined;
+  getCurrentUser?: () => KubeConfigUser | undefined;
+  getContextObject?: (name: string) => KubeConfigContext | undefined;
+  clusters?: KubeConfigCluster[];
+  users?: KubeConfigUser[];
+  contexts?: KubeConfigContext[];
+  currentContext?: string;
+};
+
+const loadKubeModule = (): {
+  KubeConfig: new () => KubeConfigLike;
+  CoreV1Api: new () => unknown;
+} => {
+  let module: { KubeConfig: new () => KubeConfigLike; CoreV1Api: new () => unknown };
   try {
     module = requireModule("@kubernetes/client-node");
   } catch {
@@ -208,36 +251,187 @@ const loadClient = (context?: string): K8sClient => {
       "Kubernetes backend requires @kubernetes/client-node. Install it to enable this backend.",
     );
   }
+  return module;
+};
 
-  const { KubeConfig, CoreV1Api } = module;
+const loadKubeConfig = (context?: string): { kc: KubeConfigLike; CoreV1Api: new () => unknown } => {
+  const { KubeConfig, CoreV1Api } = loadKubeModule();
   const kc = new KubeConfig();
   kc.loadFromDefault();
   if (context) {
     kc.setCurrentContext(context);
   }
-  const client = kc.makeApiClient(CoreV1Api) as unknown as K8sClient;
-  return client;
+  return { kc, CoreV1Api };
+};
+
+const getCurrentContextName = (kc: KubeConfigLike): string | undefined => {
+  return kc.getCurrentContext?.() ?? kc.currentContext;
+};
+
+const getContextObject = (kc: KubeConfigLike, name?: string): KubeConfigContext | undefined => {
+  if (!name) {
+    return undefined;
+  }
+  const direct = kc.getContextObject?.(name);
+  if (direct) {
+    return direct;
+  }
+  const contexts = Array.isArray(kc.contexts) ? kc.contexts : [];
+  return contexts.find((context) => context.name === name);
+};
+
+const getCurrentCluster = (kc: KubeConfigLike): KubeConfigCluster | undefined => {
+  const direct = kc.getCurrentCluster?.();
+  if (direct) {
+    return direct;
+  }
+  const currentContext = getContextObject(kc, getCurrentContextName(kc));
+  const clusterName = currentContext?.cluster;
+  if (!clusterName) {
+    return undefined;
+  }
+  const clusters = Array.isArray(kc.clusters) ? kc.clusters : [];
+  return clusters.find((cluster) => cluster.name === clusterName);
+};
+
+const getCurrentUser = (kc: KubeConfigLike): KubeConfigUser | undefined => {
+  const direct = kc.getCurrentUser?.();
+  if (direct) {
+    return direct;
+  }
+  const currentContext = getContextObject(kc, getCurrentContextName(kc));
+  const userName = currentContext?.user;
+  if (!userName) {
+    return undefined;
+  }
+  const users = Array.isArray(kc.users) ? kc.users : [];
+  return users.find((user) => user.name === userName);
+};
+
+const getEnvValue = (env: KubeConfigUserExec["env"], key: string): string | undefined => {
+  if (!env) {
+    return undefined;
+  }
+  for (const entry of env) {
+    if (entry?.name === key && entry.value) {
+      return entry.value;
+    }
+  }
+  return undefined;
+};
+
+const findArgValue = (args: string[], name: string): string | undefined => {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) {
+      continue;
+    }
+    if (arg === name && args[i + 1]) {
+      return args[i + 1];
+    }
+    const prefix = `${name}=`;
+    if (arg.startsWith(prefix)) {
+      return arg.slice(prefix.length);
+    }
+  }
+  return undefined;
+};
+
+const parseAwsEksExec = (
+  exec?: KubeConfigUserExec,
+): { clusterName: string; region: string; profile?: string } | null => {
+  if (!exec) {
+    return null;
+  }
+  const command = exec.command ?? "";
+  const commandName = command.split(/[\\/]/).pop() ?? command;
+  const args = exec.args ?? [];
+  const isAws = commandName === "aws";
+  const hasEks = args.includes("eks");
+  const hasGetToken = args.includes("get-token");
+  if (!isAws || !hasEks || !hasGetToken) {
+    return null;
+  }
+
+  const region = findArgValue(args, "--region");
+  const clusterName = findArgValue(args, "--cluster-name");
+  if (!region || !clusterName) {
+    throw new Error(
+      "Kubernetes backend found aws eks exec config but missing --region or --cluster-name.",
+    );
+  }
+  const profile = findArgValue(args, "--profile") ?? getEnvValue(exec.env, "AWS_PROFILE");
+  return { clusterName, region, profile };
+};
+
+const buildKubeConfigWithToken = (input: {
+  clusterName: string;
+  server: string;
+  caData?: string;
+  skipTLSVerify?: boolean;
+  namespace?: string;
+  token: string;
+}): KubeConfigLike => {
+  const { KubeConfig } = loadKubeModule();
+  const kc = new KubeConfig();
+  if (!kc.loadFromOptions) {
+    throw new Error("Kubernetes client does not support loadFromOptions.");
+  }
+  const userName = `${input.clusterName}-token-user`;
+  const contextName = `${input.clusterName}-token-context`;
+  kc.loadFromOptions({
+    clusters: [
+      {
+        name: input.clusterName,
+        server: input.server,
+        caData: input.caData,
+        skipTLSVerify: input.skipTLSVerify,
+      },
+    ],
+    users: [{ name: userName, token: input.token }],
+    contexts: [
+      {
+        name: contextName,
+        cluster: input.clusterName,
+        user: userName,
+        namespace: input.namespace,
+      },
+    ],
+    currentContext: contextName,
+  });
+  return kc;
 };
 
 const listNamespacedPod = async (
   client: K8sClient,
   params: { namespace: string; labelSelector?: string },
 ): Promise<{ body: { items: Array<{ metadata?: { name?: string } }> } }> => {
-  const listFn = client.listNamespacedPod;
-  if (listFn.length <= 1) {
-    return listFn({
+  const listFn = client.listNamespacedPod.bind(client);
+  const useObjectParams = Boolean(client.api) || listFn.length <= 1;
+  const response = useObjectParams
+    ? await listFn({
       namespace: params.namespace,
       labelSelector: params.labelSelector,
-    });
+    })
+    : await listFn(
+        params.namespace,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        params.labelSelector,
+      );
+
+  if (response && typeof response === "object") {
+    if ("body" in response && response.body && typeof response.body === "object") {
+      return response as { body: { items: Array<{ metadata?: { name?: string } }> } };
+    }
+    if ("items" in response && Array.isArray((response as { items?: unknown }).items)) {
+      return { body: { items: (response as { items: Array<{ metadata?: { name?: string } }> }).items } };
+    }
   }
-  return listFn(
-    params.namespace,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    params.labelSelector,
-  );
+
+  throw new Error("Unexpected response from listNamespacedPod.");
 };
 
 const readNamespacedPodLog = async (
@@ -251,28 +445,36 @@ const readNamespacedPodLog = async (
     timestamps?: boolean;
   },
 ): Promise<{ body: string }> => {
-  const readFn = client.readNamespacedPodLog;
-  if (readFn.length <= 1) {
-    return readFn({
+  const readFn = client.readNamespacedPodLog.bind(client);
+  const useObjectParams = Boolean(client.api) || readFn.length <= 1;
+  const response = useObjectParams
+    ? await readFn({
       name: params.name,
       namespace: params.namespace,
       container: params.container,
       follow: params.follow,
       sinceSeconds: params.sinceSeconds,
       timestamps: params.timestamps,
-    });
+    })
+    : await readFn(
+        params.name,
+        params.namespace,
+        params.container,
+        params.follow,
+        undefined,
+        undefined,
+        params.sinceSeconds,
+        undefined,
+        params.timestamps,
+      );
+
+  if (typeof response === "string") {
+    return { body: response };
   }
-  return readFn(
-    params.name,
-    params.namespace,
-    params.container,
-    params.follow,
-    undefined,
-    undefined,
-    params.sinceSeconds,
-    undefined,
-    params.timestamps,
-  );
+  if (response && typeof response === "object" && "body" in response) {
+    return response as { body: string };
+  }
+  throw new Error("Unexpected response from readNamespacedPodLog.");
 };
 
 const parseLogLine = (line: string): { ts: string; message: string } => {
@@ -293,15 +495,122 @@ const parseLogLine = (line: string): { ts: string; message: string } => {
 
 export const createK8sBackend = (config: GuckK8sReadBackendConfig): ReadBackend => {
   let client: K8sClient | null = null;
-  const getClient = (): K8sClient => {
-    if (!client) {
-      client = loadClient(config.context);
+  let clientPromise: Promise<K8sClient> | null = null;
+  let tokenExpiresAtMs: number | null = null;
+  let cachedEksConfig:
+    | { clusterName: string; region: string; profile?: string }
+    | null
+    | undefined;
+  let cachedCluster:
+    | { name: string; server: string; caData?: string; skipTLSVerify?: boolean; namespace?: string }
+    | null = null;
+
+  const resolveEksConfig = (kc: KubeConfigLike): { clusterName: string; region: string; profile?: string } | null => {
+    if (cachedEksConfig !== undefined) {
+      return cachedEksConfig;
     }
-    return client;
+    if (config.clusterName && config.region) {
+      cachedEksConfig = {
+        clusterName: config.clusterName,
+        region: config.region,
+        profile: config.profile,
+      };
+      return cachedEksConfig;
+    }
+    const parsed = parseAwsEksExec(getCurrentUser(kc)?.exec);
+    if (!parsed) {
+      cachedEksConfig = null;
+      return cachedEksConfig;
+    }
+    cachedEksConfig = {
+      clusterName: parsed.clusterName,
+      region: parsed.region,
+      profile: config.profile ?? parsed.profile,
+    };
+    return cachedEksConfig;
+  };
+
+  const resolveClusterInfo = async (
+    kc: KubeConfigLike,
+    eksConfig: { clusterName: string; region: string; profile?: string },
+  ): Promise<{ name: string; server: string; caData?: string; skipTLSVerify?: boolean; namespace?: string }> => {
+    if (cachedCluster) {
+      return cachedCluster;
+    }
+    const currentCluster = getCurrentCluster(kc);
+    const currentContext = getContextObject(kc, getCurrentContextName(kc));
+    const namespace = currentContext?.namespace;
+    let server = currentCluster?.server;
+    let caData = currentCluster?.caData;
+    const skipTLSVerify = currentCluster?.skipTLSVerify;
+
+    if (!server || !caData) {
+      const fetched = await fetchEksClusterInfo({
+        clusterName: eksConfig.clusterName,
+        region: eksConfig.region,
+        profile: eksConfig.profile,
+      });
+      server = server ?? fetched.endpoint;
+      caData = caData ?? fetched.certificateAuthorityData;
+    }
+
+    if (!server) {
+      throw new Error(`EKS cluster ${eksConfig.clusterName} has no endpoint configured.`);
+    }
+    cachedCluster = {
+      name: currentCluster?.name ?? eksConfig.clusterName,
+      server,
+      caData,
+      skipTLSVerify,
+      namespace,
+    };
+    return cachedCluster;
+  };
+
+  const getClient = async (): Promise<K8sClient> => {
+    if (client && tokenExpiresAtMs === null) {
+      return client;
+    }
+    const now = Date.now();
+    if (client && tokenExpiresAtMs && tokenExpiresAtMs - 30_000 > now) {
+      return client;
+    }
+    if (clientPromise) {
+      return clientPromise;
+    }
+    clientPromise = (async () => {
+      const { kc, CoreV1Api } = loadKubeConfig(config.context);
+      const eksConfig = resolveEksConfig(kc);
+      if (!eksConfig) {
+        client = kc.makeApiClient(CoreV1Api) as unknown as K8sClient;
+        tokenExpiresAtMs = null;
+        return client;
+      }
+      const clusterInfo = await resolveClusterInfo(kc, eksConfig);
+      const tokenResult = await buildEksToken({
+        clusterName: eksConfig.clusterName,
+        region: eksConfig.region,
+        profile: eksConfig.profile,
+      });
+      const tokenConfig = buildKubeConfigWithToken({
+        clusterName: clusterInfo.name,
+        server: clusterInfo.server,
+        caData: clusterInfo.caData,
+        skipTLSVerify: clusterInfo.skipTLSVerify,
+        namespace: clusterInfo.namespace,
+        token: tokenResult.token,
+      });
+      client = tokenConfig.makeApiClient(CoreV1Api) as unknown as K8sClient;
+      tokenExpiresAtMs = tokenResult.expiresAtMs;
+      return client;
+    })().finally(() => {
+      clientPromise = null;
+    });
+    return clientPromise;
   };
 
   const fetchEvents = async (params: GuckSearchParams): Promise<SearchResult> => {
-    const client = getClient();
+    const client = await getClient();
     const sinceMs = params.since ? parseTimeInput(params.since) : undefined;
     const untilMs = params.until ? parseTimeInput(params.until) : undefined;
     const sinceSeconds =

--- a/packages/guck-core/test/eks-auth.test.js
+++ b/packages/guck-core/test/eks-auth.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildEksToken } from "../dist/store/backends/eks-auth.js";
+
+const decodeBase64Url = (value) => {
+  let normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  while (normalized.length % 4 !== 0) {
+    normalized += "=";
+  }
+  return Buffer.from(normalized, "base64").toString("utf8");
+};
+
+test("buildEksToken uses presigned GetCallerIdentity URL", async (t) => {
+  try {
+    const now = new Date("2024-01-01T00:00:00.000Z");
+    const result = await buildEksToken({
+      clusterName: "eks-example",
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "AKIDEXAMPLE",
+        secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        sessionToken: "token",
+      },
+      expiresInSeconds: 60,
+      now,
+    });
+    assert.ok(result.token.startsWith("k8s-aws-v1."));
+    const encoded = result.token.slice("k8s-aws-v1.".length);
+    const url = decodeBase64Url(encoded);
+    assert.match(url, /X-Amz-Algorithm=AWS4-HMAC-SHA256/);
+    assert.match(url, /X-Amz-SignedHeaders=.*x-k8s-aws-id/);
+    assert.equal(result.expiresAtMs, now.getTime() + 60 * 1000);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("EKS auth requires")) {
+      t.skip("Optional AWS SDK deps not installed.");
+      return;
+    }
+    throw error;
+  }
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,12 +65,27 @@ importers:
       '@aws-sdk/client-cloudwatch-logs':
         specifier: 3.985.0
         version: 3.985.0
+      '@aws-sdk/client-eks':
+        specifier: 3.985.0
+        version: 3.985.0
+      '@aws-sdk/client-sts':
+        specifier: 3.985.0
+        version: 3.985.0
       '@aws-sdk/credential-providers':
         specifier: 3.985.0
         version: 3.985.0
       '@kubernetes/client-node':
         specifier: 1.4.0
         version: 1.4.0
+      '@smithy/hash-node':
+        specifier: 4.2.8
+        version: 4.2.8
+      '@smithy/protocol-http':
+        specifier: 5.3.8
+        version: 5.3.8
+      '@smithy/signature-v4':
+        specifier: 5.3.8
+        version: 5.3.8
 
   packages/guck-js:
     dependencies:
@@ -142,8 +157,16 @@ packages:
     resolution: {integrity: sha512-PpHgiNGLsnQ2QHh0wx/uhGV3kxlASp2LOl5Z+LQCnu59i8rjAH1decT03QNWcho3Jz4zg9Kcto6VoAxu6OFb2A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-eks@3.985.0':
+    resolution: {integrity: sha512-mpDdf0fmDJSnBFv11cGJ8EtF8cQ/1eG/bpC/kLwaDzB6gsWJ8Qa9ls7fuCHbnFURopIpdhbcJDSXDovwpajCRA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sso@3.985.0':
     resolution: {integrity: sha512-81J8iE8MuXhdbMfIz4sWFj64Pe41bFi/uqqmqOC5SlGv+kwoyLsyKS/rH2tW2t5buih4vTUxskRjxlqikTD4oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sts@3.985.0':
+    resolution: {integrity: sha512-YKj2f0FZAXQ/s1460PoVJOGijDwMycknSbDO7EZQnR0TZh5I12AUZzAiNEOXltKJ0TSHex2YDuNwGmlzvXoeuw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.7':
@@ -949,6 +972,10 @@ packages:
 
   '@smithy/util-utf8@4.2.0':
     resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.8':
+    resolution: {integrity: sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.0':
@@ -2864,11 +2891,102 @@ snapshots:
       - aws-crt
     optional: true
 
+  '@aws-sdk/client-eks@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
   '@aws-sdk/client-sso@3.985.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.973.7
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.22.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.13
+      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.2
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.29
+      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+    optional: true
+
+  '@aws-sdk/client-sts@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/credential-provider-node': 3.972.6
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
@@ -4092,6 +4210,13 @@ snapshots:
   '@smithy/util-utf8@4.2.0':
     dependencies:
       '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@smithy/util-waiter@4.2.8':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
     optional: true
 


### PR DESCRIPTION
## Summary
- add EKS token generation via AWS SDK for kubeconfig exec auth
- improve K8s client compatibility for object/positional method signatures
- document EKS config fields and add basic token test

## Testing
- `pnpm -C packages/guck-core build`

Fixes #58