### PR TITLE
feat: cap mcp output length

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,12 @@ export GUCK_SESSION_ID=dev-2026-02-10
     "keys": ["authorization","api_key","token","secret","password"],
     "patterns": ["sk-[A-Za-z0-9]{20,}","Bearer\\s+[A-Za-z0-9._-]+"]
   },
-  "mcp": { "max_results": 200, "default_lookback_ms": 300000 }
+  "mcp": {
+    "max_results": 200,
+    "default_lookback_ms": 300000,
+    "max_output_chars": 0,
+    "max_message_chars": 0
+  }
 }
 ```
 
@@ -257,6 +262,8 @@ HTTP ingest config (optional defaults shown):
   "mcp": {
     "max_results": 200,
     "default_lookback_ms": 300000,
+    "max_output_chars": 0,
+    "max_message_chars": 0,
     "http": {
       "host": "127.0.0.1",
       "path": "/guck/emit",
@@ -352,6 +359,10 @@ Guck exposes these MCP tools (filter-first):
 - `format` — `json` (default) or `text`.
 - `fields` — when `format: "json"`, project events to these top-level fields.
 - `template` — when `format: "text"`, format each line using tokens like `{ts}|{service}|{message}`. Missing tokens become empty strings.
+- `max_output_chars` — cap total response size in characters (set `max_message_chars` or use `fields/template` to shrink output).
+- `max_message_chars` — truncate `event.message` before formatting/projection.
+
+When `max_output_chars` is exceeded, responses include `warning` and set `truncated: true`. Set either value to `0` (or omit it) to disable the cap.
 
 Examples:
 

--- a/packages/guck-core/src/config.ts
+++ b/packages/guck-core/src/config.ts
@@ -23,6 +23,8 @@ const DEFAULT_CONFIG: GuckConfig = {
   mcp: {
     max_results: 200,
     default_lookback_ms: 300000,
+    max_output_chars: 0,
+    max_message_chars: 0,
     http: {
       host: "127.0.0.1",
       path: "/guck/emit",

--- a/packages/guck-core/src/format.ts
+++ b/packages/guck-core/src/format.ts
@@ -31,6 +31,31 @@ const stringifyValue = (value: unknown): string => {
   }
 };
 
+const truncateString = (value: string, maxChars: number): string => {
+  if (maxChars <= 0 || value.length <= maxChars) {
+    return value;
+  }
+  const suffix = "...";
+  if (maxChars <= suffix.length) {
+    return value.slice(0, maxChars);
+  }
+  return value.slice(0, maxChars - suffix.length) + suffix;
+};
+
+export const truncateEventMessage = (
+  event: GuckEvent,
+  maxChars?: number,
+): GuckEvent => {
+  if (!maxChars || maxChars <= 0) {
+    return event;
+  }
+  const message = event.message;
+  if (!message || message.length <= maxChars) {
+    return event;
+  }
+  return { ...event, message: truncateString(message, maxChars) };
+};
+
 export const projectEventFields = (
   event: GuckEvent,
   fields: string[],

--- a/packages/guck-core/src/schema.ts
+++ b/packages/guck-core/src/schema.ts
@@ -57,6 +57,8 @@ export type GuckMcpHttpConfig = {
 export type GuckMcpConfig = {
   max_results: number;
   default_lookback_ms: number;
+  max_output_chars?: number;
+  max_message_chars?: number;
   http?: GuckMcpHttpConfig;
 };
 
@@ -108,6 +110,8 @@ export type GuckSearchParams = {
   since?: string;
   until?: string;
   limit?: number;
+  max_output_chars?: number;
+  max_message_chars?: number;
   format?: "json" | "text";
   fields?: string[];
   template?: string;
@@ -140,6 +144,8 @@ export type GuckTailParams = {
   run_id?: string;
   limit?: number;
   query?: string;
+  max_output_chars?: number;
+  max_message_chars?: number;
   format?: "json" | "text";
   fields?: string[];
   template?: string;

--- a/packages/guck-core/test/format.test.js
+++ b/packages/guck-core/test/format.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { formatEventText, projectEventFields } from "../dist/format.js";
+import { formatEventText, projectEventFields, truncateEventMessage } from "../dist/format.js";
 
 const baseEvent = {
   id: "1",
@@ -48,4 +48,19 @@ test("formatEventText template", () => {
 test("formatEventText template missing fields and json values", () => {
   const text = formatEventText(baseEvent, "{ts}|{missing}|{data}|{tags}");
   assert.equal(text, "2026-02-09T00:00:00.000Z||{\"stage\":\"x\"}|{\"env\":\"test\"}");
+});
+
+test("truncateEventMessage leaves short messages", () => {
+  const truncated = truncateEventMessage(baseEvent, 10);
+  assert.equal(truncated.message, "hello");
+});
+
+test("truncateEventMessage truncates with suffix", () => {
+  const truncated = truncateEventMessage({ ...baseEvent, message: "hello world" }, 8);
+  assert.equal(truncated.message, "hello...");
+});
+
+test("truncateEventMessage respects tiny limits", () => {
+  const truncated = truncateEventMessage({ ...baseEvent, message: "hello" }, 2);
+  assert.equal(truncated.message, "he");
 });

--- a/packages/guck-py/src/guck/config.py
+++ b/packages/guck-py/src/guck/config.py
@@ -25,6 +25,8 @@ DEFAULT_CONFIG: GuckConfig = {
     "mcp": {
         "max_results": 200,
         "default_lookback_ms": 300000,
+        "max_output_chars": 0,
+        "max_message_chars": 0,
     },
 }
 

--- a/packages/guck-py/src/guck/schema.py
+++ b/packages/guck-py/src/guck/schema.py
@@ -38,6 +38,8 @@ class GuckRedactionConfig(TypedDict):
 class GuckMcpConfig(TypedDict):
     max_results: int
     default_lookback_ms: int
+    max_output_chars: int
+    max_message_chars: int
     http: "GuckMcpHttpConfig"
 
 


### PR DESCRIPTION
## Summary
- add max_output_chars + max_message_chars caps for guck.search/guck.tail output
- truncate messages before formatting and emit warning when payload is trimmed
- update config defaults, schemas, and docs; add format truncation tests

## Testing
- pnpm -C packages/guck-core test

Fixes #64