### PR TITLE
feat: cap mcp output length

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,12 @@ If you need a custom location, set `GUCK_DIR` on the **server** process
     "keys": ["authorization","api_key","token","secret","password"],
     "patterns": ["sk-[A-Za-z0-9]{20,}","Bearer\\s+[A-Za-z0-9._-]+"]
   },
-  "mcp": { "max_results": 200, "default_lookback_ms": 300000 }
+  "mcp": {
+    "max_results": 200,
+    "default_lookback_ms": 300000,
+    "max_output_chars": 0,
+    "max_message_chars": 0
+  }
 }
 ```
 
@@ -342,6 +347,10 @@ Guck exposes these MCP tools (filter-first):
 - `format` — `json` (default) or `text`.
 - `fields` — when `format: "json"`, project events to these top-level fields.
 - `template` — when `format: "text"`, format each line using tokens like `{ts}|{service}|{message}`. Missing tokens become empty strings.
+- `max_output_chars` — cap total response size in characters (set `max_message_chars` or use `fields/template` to shrink output).
+- `max_message_chars` — truncate `event.message` before formatting/projection.
+
+When `max_output_chars` is exceeded, responses include `warning` and set `truncated: true`. Set either value to `0` (or omit it) to disable the cap.
 
 Examples:
 

--- a/packages/guck-core/src/config.ts
+++ b/packages/guck-core/src/config.ts
@@ -23,6 +23,8 @@ const DEFAULT_CONFIG: GuckConfig = {
   mcp: {
     max_results: 200,
     default_lookback_ms: 300000,
+    max_output_chars: 0,
+    max_message_chars: 0,
   },
 };
 

--- a/packages/guck-core/src/format.ts
+++ b/packages/guck-core/src/format.ts
@@ -31,6 +31,31 @@ const stringifyValue = (value: unknown): string => {
   }
 };
 
+const truncateString = (value: string, maxChars: number): string => {
+  if (maxChars <= 0 || value.length <= maxChars) {
+    return value;
+  }
+  const suffix = "...";
+  if (maxChars <= suffix.length) {
+    return value.slice(0, maxChars);
+  }
+  return value.slice(0, maxChars - suffix.length) + suffix;
+};
+
+export const truncateEventMessage = (
+  event: GuckEvent,
+  maxChars?: number,
+): GuckEvent => {
+  if (!maxChars || maxChars <= 0) {
+    return event;
+  }
+  const message = event.message;
+  if (!message || message.length <= maxChars) {
+    return event;
+  }
+  return { ...event, message: truncateString(message, maxChars) };
+};
+
 export const projectEventFields = (
   event: GuckEvent,
   fields: string[],

--- a/packages/guck-core/src/schema.ts
+++ b/packages/guck-core/src/schema.ts
@@ -49,6 +49,8 @@ export type GuckConfig = {
 export type GuckMcpConfig = {
   max_results: number;
   default_lookback_ms: number;
+  max_output_chars?: number;
+  max_message_chars?: number;
 };
 
 export type GuckReadBackendType = "local" | "cloudwatch" | "k8s";
@@ -102,6 +104,8 @@ export type GuckSearchParams = {
   since?: string;
   until?: string;
   limit?: number;
+  max_output_chars?: number;
+  max_message_chars?: number;
   format?: "json" | "text";
   fields?: string[];
   template?: string;
@@ -134,6 +138,8 @@ export type GuckTailParams = {
   run_id?: string;
   limit?: number;
   query?: string;
+  max_output_chars?: number;
+  max_message_chars?: number;
   format?: "json" | "text";
   fields?: string[];
   template?: string;

--- a/packages/guck-core/test/format.test.js
+++ b/packages/guck-core/test/format.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { formatEventText, projectEventFields } from "../dist/format.js";
+import { formatEventText, projectEventFields, truncateEventMessage } from "../dist/format.js";
 
 const baseEvent = {
   id: "1",
@@ -48,4 +48,19 @@ test("formatEventText template", () => {
 test("formatEventText template missing fields and json values", () => {
   const text = formatEventText(baseEvent, "{ts}|{missing}|{data}|{tags}");
   assert.equal(text, "2026-02-09T00:00:00.000Z||{\"stage\":\"x\"}|{\"env\":\"test\"}");
+});
+
+test("truncateEventMessage leaves short messages", () => {
+  const truncated = truncateEventMessage(baseEvent, 10);
+  assert.equal(truncated.message, "hello");
+});
+
+test("truncateEventMessage truncates with suffix", () => {
+  const truncated = truncateEventMessage({ ...baseEvent, message: "hello world" }, 8);
+  assert.equal(truncated.message, "hello...");
+});
+
+test("truncateEventMessage respects tiny limits", () => {
+  const truncated = truncateEventMessage({ ...baseEvent, message: "hello" }, 2);
+  assert.equal(truncated.message, "he");
 });

--- a/packages/guck-mcp/src/server.ts
+++ b/packages/guck-mcp/src/server.ts
@@ -20,6 +20,7 @@ import {
   readTail,
   redactEvent,
   resolveStoreDir,
+  truncateEventMessage,
 } from "@guckdev/core";
 const SEARCH_SCHEMA = {
   type: "object",
@@ -74,6 +75,16 @@ const SEARCH_SCHEMA = {
       type: "number",
       description:
         "Maximum number of events to return (defaults to config.mcp.max_results).",
+    },
+    max_output_chars: {
+      type: "number",
+      description:
+        "Maximum total characters to return in the response payload (uses config.mcp.max_output_chars when omitted).",
+    },
+    max_message_chars: {
+      type: "number",
+      description:
+        "Truncate event.message to this length before formatting (uses config.mcp.max_message_chars when omitted).",
     },
     format: {
       type: "string",
@@ -143,6 +154,16 @@ const TAIL_SCHEMA = {
     run_id: { type: "string" },
     limit: { type: "number" },
     query: { type: "string" },
+    max_output_chars: {
+      type: "number",
+      description:
+        "Maximum total characters to return in the response payload (uses config.mcp.max_output_chars when omitted).",
+    },
+    max_message_chars: {
+      type: "number",
+      description:
+        "Truncate event.message to this length before formatting (uses config.mcp.max_message_chars when omitted).",
+    },
     format: { type: "string", enum: ["json", "text"] },
     fields: { type: "array", items: { type: "string" } },
     template: { type: "string" },
@@ -160,6 +181,83 @@ const buildText = (payload: unknown) => {
       },
     ],
   };
+};
+
+const OUTPUT_LIMIT_WARNING =
+  "Output truncated to fit max_output_chars. Consider using fields/template or max_message_chars to reduce size.";
+
+const normalizeMaxChars = (value: number | undefined): number | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.floor(value);
+  if (normalized <= 0) {
+    return undefined;
+  }
+  return normalized;
+};
+
+const resolveMaxChars = (
+  value: number | undefined,
+  fallback: number | undefined,
+): number | undefined => {
+  return normalizeMaxChars(value ?? fallback);
+};
+
+const payloadLength = (payload: unknown): number => {
+  return JSON.stringify(payload, null, 2).length;
+};
+
+const limitPayloadItems = <T>(
+  items: T[],
+  maxOutputChars: number | undefined,
+  buildPayload: (items: T[], truncated: boolean, warning?: string) => unknown,
+  baseTruncated: boolean,
+): { items: T[]; truncated: boolean; warning?: string } => {
+  if (!maxOutputChars) {
+    return { items, truncated: baseTruncated };
+  }
+
+  const limited: T[] = [];
+  let truncated = baseTruncated;
+  let warning: string | undefined;
+
+  for (const item of items) {
+    const candidate = [...limited, item];
+    if (payloadLength(buildPayload(candidate, truncated, warning)) <= maxOutputChars) {
+      limited.push(item);
+      continue;
+    }
+    warning = OUTPUT_LIMIT_WARNING;
+    truncated = true;
+    if (payloadLength(buildPayload(limited, truncated, warning)) <= maxOutputChars) {
+      return { items: limited, truncated, warning };
+    }
+    while (limited.length > 0) {
+      limited.pop();
+      if (payloadLength(buildPayload(limited, truncated, warning)) <= maxOutputChars) {
+        return { items: limited, truncated, warning };
+      }
+    }
+    return { items: [], truncated: true, warning };
+  }
+
+  if (payloadLength(buildPayload(limited, truncated, warning)) <= maxOutputChars) {
+    return { items: limited, truncated, warning };
+  }
+
+  warning = OUTPUT_LIMIT_WARNING;
+  truncated = true;
+  while (limited.length > 0) {
+    limited.pop();
+    if (payloadLength(buildPayload(limited, truncated, warning)) <= maxOutputChars) {
+      return { items: limited, truncated, warning };
+    }
+  }
+  return { items: [], truncated: true, warning };
 };
 
 const resolveSince = (
@@ -255,26 +353,81 @@ export const startMcpServer = async (options: McpServerOptions = {}): Promise<vo
       };
       try {
         const result = await readSearch(config, rootDir, withDefaults);
+        const maxMessageChars = resolveMaxChars(
+          input.max_message_chars,
+          config.mcp.max_message_chars,
+        );
+        const maxOutputChars = resolveMaxChars(
+          input.max_output_chars,
+          config.mcp.max_output_chars,
+        );
         const redacted = result.events.map((event) => redactEvent(config, event));
+        const trimmed = maxMessageChars
+          ? redacted.map((event) => truncateEventMessage(event, maxMessageChars))
+          : redacted;
         if (input.format === "text") {
-          const lines = redacted.map((event) => formatEventText(event, input.template));
+          const lines = trimmed.map((event) => formatEventText(event, input.template));
+          const limited = limitPayloadItems(
+            lines,
+            maxOutputChars,
+            (items, truncated, warning) => ({
+              format: "text",
+              lines: items,
+              truncated,
+              errors: result.errors,
+              warning,
+            }),
+            result.truncated,
+          );
           return buildText({
             format: "text",
-            lines,
-            truncated: result.truncated,
+            lines: limited.items,
+            truncated: limited.truncated,
             errors: result.errors,
+            warning: limited.warning,
           });
         }
         if (input.fields && input.fields.length > 0) {
-          const projected = redacted.map((event) => projectEventFields(event, input.fields ?? []));
+          const projected = trimmed.map((event) => projectEventFields(event, input.fields ?? []));
+          const limited = limitPayloadItems(
+            projected,
+            maxOutputChars,
+            (items, truncated, warning) => ({
+              format: "json",
+              events: items,
+              truncated,
+              errors: result.errors,
+              warning,
+            }),
+            result.truncated,
+          );
           return buildText({
             format: "json",
-            events: projected,
-            truncated: result.truncated,
+            events: limited.items,
+            truncated: limited.truncated,
             errors: result.errors,
+            warning: limited.warning,
           });
         }
-        return buildText({ format: "json", ...result, events: redacted });
+        const limited = limitPayloadItems(
+          trimmed,
+          maxOutputChars,
+          (items, truncated, warning) => ({
+            format: "json",
+            events: items,
+            truncated,
+            errors: result.errors,
+            warning,
+          }),
+          result.truncated,
+        );
+        return buildText({
+          format: "json",
+          events: limited.items,
+          truncated: limited.truncated,
+          errors: result.errors,
+          warning: limited.warning,
+        });
       } catch (error) {
         if (error instanceof Error && error.message.startsWith("Invalid query:")) {
           return buildText({ error: error.message, query: input.query });
@@ -327,26 +480,81 @@ export const startMcpServer = async (options: McpServerOptions = {}): Promise<vo
         }
         throw error;
       }
+      const maxMessageChars = resolveMaxChars(
+        input.max_message_chars,
+        config.mcp.max_message_chars,
+      );
+      const maxOutputChars = resolveMaxChars(
+        input.max_output_chars,
+        config.mcp.max_output_chars,
+      );
       const redacted = result.events.map((event) => redactEvent(config, event));
+      const trimmed = maxMessageChars
+        ? redacted.map((event) => truncateEventMessage(event, maxMessageChars))
+        : redacted;
       if (input.format === "text") {
-        const lines = redacted.map((event) => formatEventText(event, input.template));
+        const lines = trimmed.map((event) => formatEventText(event, input.template));
+        const limited = limitPayloadItems(
+          lines,
+          maxOutputChars,
+          (items, truncated, warning) => ({
+            format: "text",
+            lines: items,
+            truncated,
+            errors: result.errors,
+            warning,
+          }),
+          result.truncated,
+        );
         return buildText({
           format: "text",
-          lines,
-          truncated: result.truncated,
+          lines: limited.items,
+          truncated: limited.truncated,
           errors: result.errors,
+          warning: limited.warning,
         });
       }
       if (input.fields && input.fields.length > 0) {
-        const projected = redacted.map((event) => projectEventFields(event, input.fields ?? []));
+        const projected = trimmed.map((event) => projectEventFields(event, input.fields ?? []));
+        const limited = limitPayloadItems(
+          projected,
+          maxOutputChars,
+          (items, truncated, warning) => ({
+            format: "json",
+            events: items,
+            truncated,
+            errors: result.errors,
+            warning,
+          }),
+          result.truncated,
+        );
         return buildText({
           format: "json",
-          events: projected,
-          truncated: result.truncated,
+          events: limited.items,
+          truncated: limited.truncated,
           errors: result.errors,
+          warning: limited.warning,
         });
       }
-      return buildText({ format: "json", ...result, events: redacted });
+      const limited = limitPayloadItems(
+        trimmed,
+        maxOutputChars,
+        (items, truncated, warning) => ({
+          format: "json",
+          events: items,
+          truncated,
+          errors: result.errors,
+          warning,
+        }),
+        result.truncated,
+      );
+      return buildText({
+        format: "json",
+        events: limited.items,
+        truncated: limited.truncated,
+        errors: result.errors,
+        warning: limited.warning,
+      });
     }
 
     throw new Error(`Unknown tool: ${request.params.name}`);

--- a/packages/guck-py/src/guck/config.py
+++ b/packages/guck-py/src/guck/config.py
@@ -24,6 +24,8 @@ DEFAULT_CONFIG: GuckConfig = {
     "mcp": {
         "max_results": 200,
         "default_lookback_ms": 300000,
+        "max_output_chars": 0,
+        "max_message_chars": 0,
     },
 }
 

--- a/packages/guck-py/src/guck/schema.py
+++ b/packages/guck-py/src/guck/schema.py
@@ -38,6 +38,8 @@ class GuckRedactionConfig(TypedDict):
 class GuckMcpConfig(TypedDict):
     max_results: int
     default_lookback_ms: int
+    max_output_chars: int
+    max_message_chars: int
 
 
 class GuckSdkConfig(TypedDict):


### PR DESCRIPTION
## Summary
- add max_output_chars + max_message_chars caps for guck.search/guck.tail output
- truncate messages before formatting and emit warning when payload is trimmed
- update config defaults, schemas, and docs; add format truncation tests

## Testing
- pnpm -C packages/guck-core test

Fixes #64