### PR TITLE
feat: add EKS auth for k8s backend

### DIFF
--- a/packages/guck-core/src/schema.ts
+++ b/packages/guck-core/src/schema.ts
@@ -70,6 +70,13 @@ export type GuckCloudWatchReadBackendConfig = {
   service?: string;
 };
 
+export type GuckK8sAuthConfig = {
+  type: "eks";
+  cluster?: string;
+  region?: string;
+  profile?: string;
+};
+
 export type GuckK8sReadBackendConfig = {
   type: "k8s";
   id?: string;
@@ -81,6 +88,7 @@ export type GuckK8sReadBackendConfig = {
   clusterName?: string;
   region?: string;
   profile?: string;
+  auth?: GuckK8sAuthConfig;
 };
 
 export type GuckReadBackendConfig =

--- a/packages/guck-core/src/store/backends/k8s.ts
+++ b/packages/guck-core/src/store/backends/k8s.ts
@@ -509,6 +509,23 @@ export const createK8sBackend = (config: GuckK8sReadBackendConfig): ReadBackend 
     if (cachedEksConfig !== undefined) {
       return cachedEksConfig;
     }
+    if (config.auth?.type === "eks") {
+      const parsed = parseAwsEksExec(getCurrentUser(kc)?.exec);
+      const clusterName =
+        config.auth.cluster ?? config.clusterName ?? parsed?.clusterName;
+      const region = config.auth.region ?? config.region ?? parsed?.region;
+      if (!clusterName || !region) {
+        throw new Error(
+          "Kubernetes EKS auth requires cluster name and region. Set read.backends[].auth.cluster/read.backends[].auth.region or configure aws eks exec args.",
+        );
+      }
+      cachedEksConfig = {
+        clusterName,
+        region,
+        profile: config.auth.profile ?? config.profile,
+      };
+      return cachedEksConfig;
+    }
     if (config.clusterName && config.region) {
       cachedEksConfig = {
         clusterName: config.clusterName,


### PR DESCRIPTION
Adds optional EKS auth mode for the k8s read backend using the AWS SDK default credential provider chain and kubeconfig-derived cluster/region. Includes automatic token refresh and optional overrides.

Fixes #67