### PR TITLE
feat: add mcp version tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ telemetry; filtering is MCP-first.
 
 Guck exposes these MCP tools (filter-first):
 
+- `guck.mcp_version` — MCP package name + version
 - `guck.search`
 - `guck.stats`
 - `guck.sessions`


### PR DESCRIPTION
## Summary
- add `guck.mcp_version` MCP tool returning package name/version
- use package version for server metadata
- document the new tool

## Testing
- not run

Fixes #71