### PR TITLE
feat: guard MCP output and add batch search

### DIFF
--- a/packages/guck-core/src/config.ts
+++ b/packages/guck-core/src/config.ts
@@ -23,7 +23,7 @@ const DEFAULT_CONFIG: GuckConfig = {
   mcp: {
     max_results: 200,
     default_lookback_ms: 300000,
-    max_output_chars: 0,
+    max_output_chars: 20000,
     max_message_chars: 0,
   },
 };

--- a/packages/guck-core/src/schema.ts
+++ b/packages/guck-core/src/schema.ts
@@ -121,6 +121,7 @@ export type GuckSearchParams = {
   template?: string;
   backends?: string[];
   config_path?: string;
+  force?: boolean;
 };
 
 export type GuckStatsParams = {
@@ -156,4 +157,5 @@ export type GuckTailParams = {
   template?: string;
   backends?: string[];
   config_path?: string;
+  force?: boolean;
 };

--- a/packages/guck-mcp/src/output.ts
+++ b/packages/guck-mcp/src/output.ts
@@ -1,0 +1,231 @@
+export type GuardPayloadOptions = {
+  payload: unknown;
+  maxChars: number;
+  force?: boolean;
+  format?: string;
+  itemCount?: number;
+  truncated?: boolean;
+  avgMessageChars?: number;
+  maxMessageChars?: number;
+  errors?: Array<{ backend: string; backend_id?: string; message: string }>;
+};
+
+type GuardOk = { kind: "ok"; serialized: string };
+type GuardBlocked = { kind: "blocked"; warningPayload: unknown };
+
+type MessageStats = {
+  avgMessageChars: number;
+  maxMessageChars: number;
+};
+
+type TrimMessageOptions = {
+  maxChars?: number;
+  match?: string;
+};
+
+const ELLIPSIS = "...";
+
+export const serializePayload = (payload: unknown): string => {
+  return JSON.stringify(payload, null, 2);
+};
+
+export const computeMessageStats = (events: Array<{ message?: unknown }>): MessageStats => {
+  let total = 0;
+  let count = 0;
+  let max = 0;
+
+  for (const event of events) {
+    if (typeof event.message !== "string") {
+      continue;
+    }
+    const len = event.message.length;
+    total += len;
+    count += 1;
+    if (len > max) {
+      max = len;
+    }
+  }
+
+  return {
+    avgMessageChars: count === 0 ? 0 : Math.round(total / count),
+    maxMessageChars: max,
+  };
+};
+
+const buildWarningPayload = ({
+  maxChars,
+  estimatedChars,
+  format,
+  itemCount,
+  truncated,
+  avgMessageChars,
+  maxMessageChars,
+  errors,
+}: {
+  maxChars: number;
+  estimatedChars: number;
+  format?: string;
+  itemCount?: number;
+  truncated?: boolean;
+  avgMessageChars?: number;
+  maxMessageChars?: number;
+  errors?: Array<{ backend: string; backend_id?: string; message: string }>;
+}): unknown => {
+  const warning: Record<string, unknown> = {
+    code: "guck.output_too_large",
+    blocked: true,
+    message: `Output exceeds mcp.max_output_chars (${maxChars}). Refine your query or pass force=true to bypass the guard.`,
+    max_output_chars: maxChars,
+    estimated_output_chars: estimatedChars,
+    format: format ?? "json",
+    item_count: itemCount ?? 0,
+    truncated: truncated ?? false,
+  };
+
+  if (avgMessageChars !== undefined) {
+    warning.avg_message_chars = avgMessageChars;
+  }
+  if (maxMessageChars !== undefined) {
+    warning.max_message_chars = maxMessageChars;
+  }
+
+  const suggestions = [
+    { action: "limit", example: { limit: 50 } },
+    { action: "fields", example: { fields: ["ts", "level", "message"] } },
+    {
+      action: "text",
+      example: { format: "text", template: "{ts}|{service}|{message}" },
+    },
+    { action: "max_message_chars", example: { max_message_chars: 200 } },
+    { action: "force", example: { force: true } },
+  ];
+
+  return {
+    warning: {
+      ...warning,
+      suggestions,
+    },
+    ...(errors && errors.length > 0 ? { errors } : {}),
+  };
+};
+
+export const guardPayload = ({
+  payload,
+  maxChars,
+  force,
+  format,
+  itemCount,
+  truncated,
+  avgMessageChars,
+  maxMessageChars,
+  errors,
+}: GuardPayloadOptions): GuardOk | GuardBlocked => {
+  const serialized = serializePayload(payload);
+  if (force || serialized.length <= maxChars) {
+    return { kind: "ok", serialized };
+  }
+  return {
+    kind: "blocked",
+    warningPayload: buildWarningPayload({
+      maxChars,
+      estimatedChars: serialized.length,
+      format,
+      itemCount,
+      truncated,
+      avgMessageChars,
+      maxMessageChars,
+      errors,
+    }),
+  };
+};
+
+export const trimMessage = (message: string, options: TrimMessageOptions): string => {
+  const { maxChars, match } = options;
+  if (!maxChars || maxChars <= 0) {
+    return message;
+  }
+  if (message.length <= maxChars) {
+    return message;
+  }
+  if (maxChars <= ELLIPSIS.length) {
+    return message.slice(0, maxChars);
+  }
+
+  const normalizedMatch = match?.toLowerCase();
+  const matchIndex = normalizedMatch
+    ? message.toLowerCase().indexOf(normalizedMatch)
+    : -1;
+
+  if (matchIndex < 0) {
+    const available = maxChars - ELLIPSIS.length;
+    const headLen = Math.ceil(available / 2);
+    const tailLen = Math.floor(available / 2);
+    const head = message.slice(0, headLen);
+    const tail = tailLen > 0 ? message.slice(message.length - tailLen) : "";
+    return `${head}${ELLIPSIS}${tail}`;
+  }
+
+  const matchLen = normalizedMatch ? normalizedMatch.length : 0;
+  const matchCenter = matchIndex + Math.floor(matchLen / 2);
+
+  const baseContentLen = Math.max(1, maxChars - 2 * ELLIPSIS.length);
+
+  const buildWindow = (contentLen: number) => {
+    const maxStart = Math.max(0, message.length - contentLen);
+    let start = matchCenter - Math.floor(contentLen / 2);
+    if (start < 0) {
+      start = 0;
+    }
+    if (start > maxStart) {
+      start = maxStart;
+    }
+    const end = Math.min(message.length, start + contentLen);
+    const trimLeft = start > 0;
+    const trimRight = end < message.length;
+    return { start, end, trimLeft, trimRight };
+  };
+
+  let { start, end, trimLeft, trimRight } = buildWindow(baseContentLen);
+  let extra = 0;
+  if (!trimLeft) {
+    extra += ELLIPSIS.length;
+  }
+  if (!trimRight) {
+    extra += ELLIPSIS.length;
+  }
+  if (extra > 0) {
+    const expandedContentLen = Math.min(message.length, baseContentLen + extra);
+    ({ start, end, trimLeft, trimRight } = buildWindow(expandedContentLen));
+  }
+
+  const prefix = trimLeft ? ELLIPSIS : "";
+  const suffix = trimRight ? ELLIPSIS : "";
+  const slice = message.slice(start, end);
+  const trimmed = `${prefix}${slice}${suffix}`;
+
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+
+  return trimmed.slice(0, maxChars);
+};
+
+export const trimEventsMessages = <T extends { message?: unknown }>(
+  events: T[],
+  options: TrimMessageOptions,
+): T[] => {
+  const { maxChars } = options;
+  if (!maxChars || maxChars <= 0) {
+    return events;
+  }
+  return events.map((event) => {
+    if (typeof event.message !== "string") {
+      return event;
+    }
+    const trimmed = trimMessage(event.message, options);
+    if (trimmed === event.message) {
+      return event;
+    }
+    return { ...event, message: trimmed };
+  });
+};

--- a/packages/guck-mcp/test/output-guard.test.js
+++ b/packages/guck-mcp/test/output-guard.test.js
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { guardPayload, trimMessage } from "../dist/output.js";
+
+test("guardPayload allows small payload", () => {
+  const payload = { format: "json", events: [{ message: "ok" }] };
+  const result = guardPayload({
+    payload,
+    maxChars: 1000,
+    format: "json",
+    itemCount: 1,
+    truncated: false,
+  });
+  assert.equal(result.kind, "ok");
+  assert.ok(result.serialized.includes("\"events\""));
+});
+
+test("guardPayload blocks large payload", () => {
+  const payload = { format: "json", events: [{ message: "x".repeat(200) }] };
+  const result = guardPayload({
+    payload,
+    maxChars: 10,
+    format: "json",
+    itemCount: 1,
+    truncated: false,
+  });
+  assert.equal(result.kind, "blocked");
+  const warning = result.warningPayload.warning;
+  assert.equal(warning.code, "guck.output_too_large");
+  assert.equal(warning.blocked, true);
+  assert.equal(warning.max_output_chars, 10);
+  assert.ok(warning.estimated_output_chars > 10);
+});
+
+test("guardPayload includes message stats", () => {
+  const payload = { format: "json", events: [{ message: "x".repeat(200) }] };
+  const result = guardPayload({
+    payload,
+    maxChars: 10,
+    format: "json",
+    itemCount: 1,
+    truncated: false,
+    avgMessageChars: 123,
+    maxMessageChars: 456,
+  });
+  assert.equal(result.kind, "blocked");
+  const warning = result.warningPayload.warning;
+  assert.equal(warning.avg_message_chars, 123);
+  assert.equal(warning.max_message_chars, 456);
+});
+
+test("guardPayload allows force override", () => {
+  const payload = { format: "json", events: [{ message: "x".repeat(200) }] };
+  const result = guardPayload({
+    payload,
+    maxChars: 10,
+    force: true,
+    format: "json",
+    itemCount: 1,
+    truncated: false,
+  });
+  assert.equal(result.kind, "ok");
+  assert.ok(result.serialized.includes("\"events\""));
+});
+
+test("trimMessage keeps match at start without leading ellipsis", () => {
+  const message = "match-start-" + "x".repeat(50);
+  const trimmed = trimMessage(message, { maxChars: 20, match: "match" });
+  assert.ok(trimmed.startsWith("match"));
+  assert.ok(trimmed.endsWith("..."));
+  assert.ok(!trimmed.startsWith("..."));
+});
+
+test("trimMessage keeps match at end without trailing ellipsis", () => {
+  const message = "x".repeat(50) + "-match";
+  const trimmed = trimMessage(message, { maxChars: 20, match: "match" });
+  assert.ok(trimmed.startsWith("..."));
+  assert.ok(trimmed.endsWith("match"));
+  assert.ok(!trimmed.endsWith("..."));
+});
+
+test("trimMessage keeps match in middle with both ellipses", () => {
+  const message = "x".repeat(20) + "match" + "y".repeat(20);
+  const trimmed = trimMessage(message, { maxChars: 20, match: "match" });
+  assert.ok(trimmed.startsWith("..."));
+  assert.ok(trimmed.endsWith("..."));
+});
+
+test("trimMessage falls back to head and tail when no match", () => {
+  const message = "abcdefghijklmnopqrstuvwxyz";
+  const trimmed = trimMessage(message, { maxChars: 10, match: "zzz" });
+  assert.ok(trimmed.includes("..."));
+  assert.ok(trimmed.startsWith("abc"));
+  assert.ok(trimmed.endsWith("xyz"));
+});


### PR DESCRIPTION
## Summary
- add mcp output size guard with force override for search/tail
- add guck.search_batch for parallel searches with per-search cap
- document token-efficient behavior and new config

## Testing
- not run (not requested)

Fixes #64