### PR TITLE
fix: restore repository url for npm provenance

### DIFF
--- a/packages/guck-browser/package.json
+++ b/packages/guck-browser/package.json
@@ -4,7 +4,7 @@
   "description": "Guck browser SDK",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-cli/package.json
+++ b/packages/guck-cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Guck telemetry capture and MCP",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-core/package.json
+++ b/packages/guck-core/package.json
@@ -4,7 +4,7 @@
   "description": "Core utilities and types for Guck telemetry",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-js/package.json
+++ b/packages/guck-js/package.json
@@ -4,7 +4,7 @@
   "description": "Guck JS SDK",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-mcp/package.json
+++ b/packages/guck-mcp/package.json
@@ -4,7 +4,7 @@
   "description": "MCP server for Guck telemetry",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/guck-vite/package.json
+++ b/packages/guck-vite/package.json
@@ -4,7 +4,7 @@
   "description": "Vite plugin for Guck browser logging",
   "repository": {
     "type": "git",
-    "url": "https://example.com/guck-repo"
+    "url": "https://github.com/tillkolter/guck-mcp"
   },
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- restore  in package metadata to the real GitHub repo
- fixes npm provenance validation failure during publish

## Testing
- not run (metadata-only change)

Fixes #79
