### PR TITLE
docs: refine README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Guck
-*German “guck!” — “take a peek”.*
+*German “guck!” — “take a peek”.* 👀
 
 Guck is a tiny, MCP-first telemetry store for agentic debugging. It captures
 JSONL telemetry events, stores them locally, and exposes a minimal MCP toolset

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Guck
+*German “guck!” — “take a peek”.*
 
 Guck is a tiny, MCP-first telemetry store for agentic debugging. It captures
 JSONL telemetry events, stores them locally, and exposes a minimal MCP toolset
 (`guck.stats`, `guck.search`, etc.) for fast, filtered queries instead of noisy
 tailing. The goal is to make LLM/agent debugging token-efficient, repeatable,
 and low-noise across languages and runtimes.
-
-*German “guck!” — “take a peek”.*
 
 Guck is designed to be:
 - **Language-agnostic**: emit JSONL from any runtime

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guck
+# guck
 *German “guck!” — “take a peek”.* 👀
 
 Guck is a tiny, MCP-first telemetry store for agentic debugging. It captures

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Guck
 
-Guck is a tiny, MCP-first telemetry store for agentic debugging. It provides
-token-efficient log analytics by capturing JSONL telemetry events and exposing
-a minimal MCP toolset for fast, filtered queries.
+Guck is a tiny, MCP-first telemetry store for agentic debugging. It captures
+JSONL telemetry events, stores them locally, and exposes a minimal MCP toolset
+(`guck.stats`, `guck.search`, etc.) for fast, filtered queries instead of noisy
+tailing. The goal is to make LLM/agent debugging token-efficient, repeatable,
+and low-noise across languages and runtimes.
+
+*German “guck!” — “take a peek”.*
 
 Guck is designed to be:
 - **Language-agnostic**: emit JSONL from any runtime


### PR DESCRIPTION
Summary
- Expand the README intro to highlight how Guck captures/stores JSONL events and offers MCP tools for quick, low-noise queries instead of relying on `tail`
- Add a note that the name is German for “take a peek,” reinforcing the project’s debugging focus
- Fixes: README emphasizes the goal of token-efficient, repeatable agent telemetry workflows

Testing
- Not run (not requested)

Use Fixes annotations